### PR TITLE
fix: IE/Edge SVG focusable issue

### DIFF
--- a/packages/icons/build/generateIcons.ts
+++ b/packages/icons/build/generateIcons.ts
@@ -58,7 +58,7 @@ export async function build(env: Environment) {
   const svgBasicNames = await normalize(env);
 
   // SVG Meta Data Flow
-  const svgMetaDataWithTheme$ = from<ThemeType>([
+  const svgMetaDataWithTheme$ = from<ThemeType[]>([
     'fill',
     'outline',
     'twotone'
@@ -77,7 +77,7 @@ export async function build(env: Environment) {
             path.resolve(env.paths.SVG_DIR, theme, `${kebabCaseName}.svg`)
           )
         ),
-        mergeMap<NameAndPath, BuildTimeIconMetaData>(
+        mergeMap<NameAndPath, Promise<BuildTimeIconMetaData>>(
           async ({ kebabCaseName, identifier }) => {
             const tryUrl = path.resolve(
               env.paths.SVG_DIR,
@@ -110,7 +110,7 @@ export async function build(env: Environment) {
 
   // Nomalized build time icon meta data
   const BuildTimeIconMetaData$ = svgMetaDataWithTheme$.pipe(
-    mergeMap<Observable<BuildTimeIconMetaData>, BuildTimeIconMetaData>(
+    mergeMap<Observable<BuildTimeIconMetaData>, Observable<BuildTimeIconMetaData>>(
       (metaData$) => metaData$
     ),
     map<BuildTimeIconMetaData, BuildTimeIconMetaData>(
@@ -202,7 +202,7 @@ export async function build(env: Environment) {
   // Index File content flow
   const indexTsTemplate = await fs.readFile(env.paths.INDEX_TEMPLATE, 'utf8');
   const indexFile$ = svgMetaDataWithTheme$.pipe(
-    mergeMap<Observable<BuildTimeIconMetaData>, BuildTimeIconMetaData>(
+    mergeMap<Observable<BuildTimeIconMetaData>, Observable<BuildTimeIconMetaData>>(
       (metaData$) => metaData$
     ),
     reduce<BuildTimeIconMetaData, string>(
@@ -227,7 +227,7 @@ export async function build(env: Environment) {
     env.paths.MANIFEST_TEMPLATE,
     'utf8'
   );
-  const manifestFile$ = from<ThemeType>(['fill', 'outline', 'twotone']).pipe(
+  const manifestFile$ = from<ThemeType[]>(['fill', 'outline', 'twotone']).pipe(
     map<ThemeType, { theme: ThemeType; names: string[] }>((theme) => ({
       theme,
       names: svgBasicNames.filter((name) =>

--- a/packages/icons/build/templates/dist.ts.template
+++ b/packages/icons/build/templates/dist.ts.template
@@ -15,7 +15,7 @@ type PathArgs = string | ([string, string]);
 function getNode(viewBox: string, ...paths: PathArgs[]): AbstractNode {
   return {
     tag: 'svg',
-    attrs: { viewBox },
+    attrs: { viewBox, focusable: false },
     children: (paths.map((path) => {
       if(Array.isArray(path)) {
         return {

--- a/packages/icons/build/templates/types.ts
+++ b/packages/icons/build/templates/types.ts
@@ -1,7 +1,7 @@
 export interface AbstractNode {
   tag: string;
   attrs: {
-    [key: string]: string;
+    [key: string]: string | boolean;
   };
   children?: AbstractNode[];
 }


### PR DESCRIPTION
in IE/Edge, SVG is focusable and a part of document's tab order by default. Adding `focusable=false` is to prevent this default behavior. Related discussion on Stack Overflow can be found [here](http://stackoverflow.com/questions/18646111/disable-onfocus-event-for-svg-element).

Also, it seems that generate function has some type issues, so I add some fix.