### PR TITLE
Convert to functional component

### DIFF
--- a/packages/icons-vue/src/components/Icon.jsx
+++ b/packages/icons-vue/src/components/Icon.jsx
@@ -17,11 +17,7 @@ const Icon = {
   props: ['type', 'primaryColor', 'secondaryColor'],
   displayName: 'IconVue',
   definitions: new MiniMap(),
-  data () {
-    return {
-      twoToneColorPalette,
-    }
-  },
+  functional: true,
   add (...icons) {
     icons.forEach((icon) => {
       Icon.definitions.set(withSuffix(icon.name, icon.theme), icon)
@@ -55,12 +51,12 @@ const Icon = {
       ...twoToneColorPalette,
     }
   },
-  render (h) {
+  render (h, context) {
     const {
       type,
       primaryColor,
       secondaryColor,
-    } = this.$props
+    } = context.props
 
     let target
     let colors = twoToneColorPalette
@@ -97,7 +93,7 @@ const Icon = {
         fill: 'currentColor',
         'aria-hidden': 'true',
       },
-      on: this.$listeners,
+      on: context.listeners,
     })
   },
 }


### PR DESCRIPTION
In Vue 2 [functional components](https://vuejs.org/v2/guide/render-function.html#Functional-Components) have a much smaller memory footprint. As this component  already uses a render function and does not use any feature missing from a functional component, I think it is worth to change.

Note that I removed the data property, but it wasn't being used through `this` in any part of the file. As it uses a render function it can reference the JS object directly without a need to make the component stateful.