### PR TITLE
Set svg default focusable=false

### DIFF
--- a/packages/icons-react/src/components/Icon.tsx
+++ b/packages/icons-react/src/components/Icon.tsx
@@ -120,7 +120,6 @@ class Icon extends React.Component<IconProps> {
       height: '1em',
       fill: 'currentColor',
       ['aria-hidden']: 'true',
-      focusable: 'false',
       ...rest
     });
   }

--- a/packages/icons/build/generateIcons.ts
+++ b/packages/icons/build/generateIcons.ts
@@ -117,6 +117,8 @@ export async function build(env: Environment) {
       ({ identifier, icon }) => {
         icon = _.cloneDeep(icon);
         if (typeof icon.icon !== 'function') {
+          icon.icon.attrs.focusable = false;
+
           if (!oldIcons.includes(icon.name)) {
             icon.icon.attrs.viewBox = '64 64 896 896';
           }

--- a/packages/icons/build/templates/dist.ts.template
+++ b/packages/icons/build/templates/dist.ts.template
@@ -15,7 +15,7 @@ type PathArgs = string | ([string, string]);
 function getNode(viewBox: string, ...paths: PathArgs[]): AbstractNode {
   return {
     tag: 'svg',
-    attrs: { viewBox },
+    attrs: { viewBox, focusable: false },
     children: (paths.map((path) => {
       if(Array.isArray(path)) {
         return {

--- a/packages/icons/build/templates/types.ts
+++ b/packages/icons/build/templates/types.ts
@@ -1,7 +1,7 @@
 export interface AbstractNode {
   tag: string;
   attrs: {
-    [key: string]: string;
+    [key: string]: string | boolean;
   };
   children?: AbstractNode[];
 }


### PR DESCRIPTION
看了一下，修改 `dist.ts.template` 生成的图标还是没有 focusable。icon json 是在 `generateIcons` 中传入的，代码比较零散。帮忙确认一下。

ref: https://github.com/ant-design/ant-design/issues/16003