### PR TITLE
doc: fix submodule path in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ yarn add @ant-design/icons-svg
 
 ## Use Library Adapter
 
-- React: See [@ant-design/icons](./packages/icons) to learn about detail usage.
+- React: See [@ant-design/icons](./packages/icons-react) to learn about detail usage.
 
 ## Build Project
 


### PR DESCRIPTION
修复 readme.md 文档路径写错的问题