### PR TITLE
fix: icon rendering proiority

### DIFF
--- a/packages/icons-react/src/components/Icon.tsx
+++ b/packages/icons-react/src/components/Icon.tsx
@@ -88,9 +88,9 @@ const Icon: React.FC<IconComponentProps> = props => {
   // component > children
   const renderInnerNode = () => {
     if (Component) {
-      return innerNode = <Component {...innerSvgProps}>{children}</Component>;
+      return <Component {...innerSvgProps}>{children}</Component>;
     }
-    
+
     if (children) {
       warning(
         Boolean(viewBox) ||
@@ -100,13 +100,15 @@ const Icon: React.FC<IconComponentProps> = props => {
         'Make sure that you provide correct `viewBox`' +
         ' prop (default `0 0 1024 1024`) to the icon.',
       );
-  
+
       return (
         <svg {...innerSvgProps} viewBox={viewBox}>
           {children}
         </svg>
       );
     }
+
+    return null;
   }
 
   let iconTabIndex = tabIndex;

--- a/packages/icons-react/src/components/Icon.tsx
+++ b/packages/icons-react/src/components/Icon.tsx
@@ -86,25 +86,27 @@ const Icon: React.FC<IconComponentProps> = props => {
   }
 
   // component > children
-  if (Component) {
-    innerNode = <Component {...innerSvgProps}>{children}</Component>;
-  }
-
-  if (children) {
-    warning(
-      Boolean(viewBox) ||
-        (React.Children.count(children) === 1 &&
-          React.isValidElement(children) &&
-          React.Children.only(children).type === 'use'),
-      'Make sure that you provide correct `viewBox`' +
-      ' prop (default `0 0 1024 1024`) to the icon.',
-    );
-
-    innerNode = (
-      <svg {...innerSvgProps} viewBox={viewBox}>
-        {children}
-      </svg>
-    );
+  const renderInnerNode = () => {
+    if (Component) {
+      return innerNode = <Component {...innerSvgProps}>{children}</Component>;
+    }
+    
+    if (children) {
+      warning(
+        Boolean(viewBox) ||
+          (React.Children.count(children) === 1 &&
+            React.isValidElement(children) &&
+            React.Children.only(children).type === 'use'),
+        'Make sure that you provide correct `viewBox`' +
+        ' prop (default `0 0 1024 1024`) to the icon.',
+      );
+  
+      return (
+        <svg {...innerSvgProps} viewBox={viewBox}>
+          {children}
+        </svg>
+      );
+    }
   }
 
   let iconTabIndex = tabIndex;
@@ -120,7 +122,7 @@ const Icon: React.FC<IconComponentProps> = props => {
       onClick={onClick}
       className={classString}
     >
-      {innerNode}
+      {renderInnerNode()}
     </span>
   );
 }

--- a/packages/icons-react/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/icons-react/tests/__snapshots__/index.test.tsx.snap
@@ -13,11 +13,26 @@ exports[`Icon \`component\` prop can access to svg defs if has children 1`] = `
     height="1em"
     width="1em"
   >
+    <defs>
+      <linearGradient
+        id="gradient"
+      >
+        <stop
+          offset="20%"
+          stop-color="#39F"
+        />
+        <stop
+          offset="90%"
+          stop-color="#F3F"
+        />
+      </linearGradient>
+    </defs>
     <title>
       Cool Home
     </title>
     <path
       d="'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z'"
+      fill="scriptUrl(#gradient)"
     />
   </svg>
 </span>
@@ -225,13 +240,14 @@ exports[`Icon should support svg react component 1`] = `
     fill="currentColor"
     focusable="false"
     height="1em"
+    viewBox="0 0 24 24"
     width="1em"
   >
     <title>
       Cool Home
     </title>
     <path
-      d="'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z'"
+      d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"
     />
   </svg>
 </span>

--- a/packages/icons-react/tests/index.test.tsx
+++ b/packages/icons-react/tests/index.test.tsx
@@ -138,6 +138,7 @@ describe('Icon', () => {
   });
 
   it('should support svg react component', () => {
+    // children props would make no sense
     const SvgComponent = props => (
       <svg viewBox="0 0 24 24" {...props}>
         <title>Cool Home</title>


### PR DESCRIPTION
related to
* https://github.com/ant-design/ant-design-icons/issues/122
* https://github.com/ant-design/ant-design/pull/18592

修复 icon 组件的图标渲染优先级，component > children