### PR TITLE
hotfix: rollback to old icon list

### DIFF
--- a/packages/icons-svg/build/constants.ts
+++ b/packages/icons-svg/build/constants.ts
@@ -1,11 +1,26 @@
 // version < antd@3.9
 export const oldIconNames = [
+  'step-backward',
+  'step-forward',
+  'fast-backward',
+  'fast-forward',
+  'forward',
+  'backward',
+  'caret-up',
+  'caret-down',
+  'caret-left',
+  'caret-right',
+  'retweet',
+  'swap-left',
+  'swap-right',
   'loading',
   'loading-3-quarters',
   'coffee',
+  'bars',
   'file-jpg',
   'inbox',
   'shopping-cart',
+  'safety',
   'medium-workmark'
 ];
 


### PR DESCRIPTION
回退旧图标集合以确保 `antd@4.x` 暂无大变更