### PR TITLE
fix: export necessary interface used by createFromIconfontCN

### DIFF
--- a/packages/icons-react/src/components/IconFont.tsx
+++ b/packages/icons-react/src/components/IconFont.tsx
@@ -8,7 +8,7 @@ export interface CustomIconOptions {
   extraCommonProps?: { [key: string]: any };
 }
 
-interface IconFontProps extends IconBaseProps {
+export interface IconFontProps extends IconBaseProps {
   type: string;
 }
 


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/22939