### PR TITLE
增加scriptUrls参数，可引入多个iconfont资源

### DIFF
--- a/packages/icons-react/examples/use-iconfontcn.tsx
+++ b/packages/icons-react/examples/use-iconfontcn.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 import { createFromIconfontCN } from '../src';
 
 const IconFont = createFromIconfontCN({
-  // scriptUrl: '//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js',
-  scriptUrl: ['//at.alicdn.com/t/font_1728622_jaz3y5gulz.js', '//at.alicdn.com/t/font_1517974_d9tp7huqb5r.js'],
+  scriptUrl: '//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js',
+  // scriptUrl: ['//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js', '//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js'],
 });
 
 const IconfontCN = () => (
   <div>
     <h1>Icons from iconfont.cn</h1>
-    <IconFont type="scanpay" />
+    <IconFont type="icon-tuichu" />
     <IconFont type="icon-facebook" />
     <IconFont type="icon-twitter" />
   </div>

--- a/packages/icons-react/examples/use-iconfontcn.tsx
+++ b/packages/icons-react/examples/use-iconfontcn.tsx
@@ -3,6 +3,7 @@ import { createFromIconfontCN } from '../src';
 
 const IconFont = createFromIconfontCN({
   scriptUrl: '//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js',
+  // scriptUrls: ['//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js'],
 });
 
 const IconfontCN = () => (

--- a/packages/icons-react/examples/use-iconfontcn.tsx
+++ b/packages/icons-react/examples/use-iconfontcn.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 import { createFromIconfontCN } from '../src';
 
 const IconFont = createFromIconfontCN({
-  scriptUrl: '//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js',
-  // scriptUrls: ['//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js'],
+  // scriptUrl: '//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js',
+  scriptUrl: ['//at.alicdn.com/t/font_1728622_jaz3y5gulz.js', '//at.alicdn.com/t/font_1517974_d9tp7huqb5r.js'],
 });
 
 const IconfontCN = () => (
   <div>
     <h1>Icons from iconfont.cn</h1>
-    <IconFont type="icon-tuichu" />
+    <IconFont type="scanpay" />
     <IconFont type="icon-facebook" />
     <IconFont type="icon-twitter" />
   </div>

--- a/packages/icons-react/src/components/IconFont.tsx
+++ b/packages/icons-react/src/components/IconFont.tsx
@@ -25,9 +25,12 @@ function createScriptUrlElements(scriptUrls: string[], index: number = 0): void 
     script.setAttribute('src', currentScriptUrl);
     script.setAttribute('data-namespace', currentScriptUrl);
     if (scriptUrls.length > index + 1) {
-      script.onload = script.onerror = () => {
+      script.onload = () => {
         createScriptUrlElements(scriptUrls, index + 1);
-      }
+      };
+      script.onerror = () => {
+        createScriptUrlElements(scriptUrls, index + 1);
+      };
     }
     customCache.add(currentScriptUrl);
     document.body.appendChild(script);

--- a/packages/icons-react/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/icons-react/tests/__snapshots__/index.test.tsx.snap
@@ -1064,3 +1064,256 @@ exports[`Icon.createFromIconfontCN() should support iconfont.cn 1`] = `
   </span>
 </div>
 `;
+
+exports[`Icon.createFromIconfontCN({scriptUrl:[]}) extraCommonProps should works fine and can be overwritten 1`] = `
+<div
+  class="icons-list"
+>
+  <span
+    class="anticon bcd"
+    role="img"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      width="1em"
+    >
+      <use
+        href="#icon-tuichu"
+      />
+    </svg>
+  </span>
+  <span
+    class="anticon abc"
+    role="img"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      width="1em"
+    >
+      <use
+        href="#icon-facebook"
+      />
+    </svg>
+  </span>
+  <span
+    class="anticon efg"
+    role="img"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      width="1em"
+    >
+      <use
+        href="#icon-twitter"
+      />
+    </svg>
+  </span>
+</div>
+`;
+
+exports[`Icon.createFromIconfontCN({scriptUrl:[]}) should support event listeners 1`] = `
+<div>
+  <Iconfont
+    onClick={[MockFunction]}
+    type="icon-tuichu"
+  >
+    <AntdIcon
+      className="abc"
+      onClick={[MockFunction]}
+    >
+      <span
+        className="anticon abc"
+        onClick={[MockFunction]}
+        role="img"
+        tabIndex={-1}
+      >
+        <svg
+          aria-hidden="true"
+          className=""
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          width="1em"
+        >
+          <use
+            xlinkHref="#icon-tuichu"
+          />
+        </svg>
+      </span>
+    </AntdIcon>
+  </Iconfont>
+  <Iconfont
+    type="icon-suofang"
+  >
+    <AntdIcon
+      className="abc"
+    >
+      <span
+        className="anticon abc"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          className=""
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          width="1em"
+        >
+          <use
+            xlinkHref="#icon-suofang"
+          />
+        </svg>
+      </span>
+    </AntdIcon>
+  </Iconfont>
+  <Iconfont
+    onMouseEnter={[MockFunction]}
+    type="icon-facebook"
+  >
+    <AntdIcon
+      className="abc"
+      onMouseEnter={[MockFunction]}
+    >
+      <span
+        className="anticon abc"
+        onMouseEnter={[MockFunction]}
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          className=""
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          width="1em"
+        >
+          <use
+            xlinkHref="#icon-facebook"
+          />
+        </svg>
+      </span>
+    </AntdIcon>
+  </Iconfont>
+  <Iconfont
+    onKeyUp={[MockFunction]}
+    spin={true}
+    type="icon-twitter"
+  >
+    <AntdIcon
+      className="abc"
+      onKeyUp={[MockFunction]}
+      spin={true}
+    >
+      <span
+        className="anticon abc"
+        onKeyUp={[MockFunction]}
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          className="anticon-spin"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          width="1em"
+        >
+          <use
+            xlinkHref="#icon-twitter"
+          />
+        </svg>
+      </span>
+    </AntdIcon>
+  </Iconfont>
+</div>
+`;
+
+exports[`Icon.createFromIconfontCN({scriptUrl:[]}) should support iconfont.cn 1`] = `
+<div
+  class="icons-list"
+>
+  <span
+    class="anticon abc"
+    role="img"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      width="1em"
+    >
+      <use
+        href="#icon-tuichu"
+      />
+    </svg>
+  </span>
+  <span
+    class="anticon abc"
+    role="img"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      width="1em"
+    >
+      <use
+        href="#icon-facebook"
+      />
+    </svg>
+  </span>
+  <span
+    class="anticon abc"
+    role="img"
+  >
+    <svg
+      aria-hidden="true"
+      class=""
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      width="1em"
+    >
+      <use
+        href="#icon-twitter"
+      />
+    </svg>
+  </span>
+</div>
+`;
+
+exports[`Icon.createFromIconfontCN({scriptUrl:[]}) should support ignore load error 1`] = `
+<span
+  class="anticon abc"
+  role="img"
+>
+  <svg
+    aria-hidden="true"
+    class=""
+    fill="currentColor"
+    focusable="false"
+    height="1em"
+    width="1em"
+  >
+    <use
+      href="#icon-facebook"
+    />
+  </svg>
+</span>
+`;

--- a/packages/icons-react/tests/index.test.tsx
+++ b/packages/icons-react/tests/index.test.tsx
@@ -359,3 +359,99 @@ describe('Icon.createFromIconfontCN()', () => {
     expect((wrapper.instance() as any).tooltip.props.visible).toBe(false);
   });
 });
+
+describe('Icon.createFromIconfontCN({scriptUrl:[]})', () => {
+  const IconFont = createFromIconfontCN({
+    scriptUrl: ['//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js'],
+    extraCommonProps: {
+      className: 'abc',
+    },
+  });
+
+  mountTest(() => <IconFont type="icon-facebook" />);
+
+  it('should support iconfont.cn', () => {
+    const wrapper = render(
+      <div className="icons-list">
+        <IconFont type="icon-tuichu" />
+        <IconFont type="icon-facebook" />
+        <IconFont type="icon-twitter" />
+      </div>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should support event listeners', () => {
+    const onClickHandler = jest.fn();
+    const onKeyUpHandler = jest.fn();
+    const onMouseEnterHandler = jest.fn();
+    const wrapper = mount(
+      <div>
+        <IconFont type="icon-tuichu" onClick={onClickHandler} />
+        <IconFont type="icon-suofang" />
+        <IconFont type="icon-facebook" onMouseEnter={onMouseEnterHandler} />
+        <IconFont type="icon-twitter" spin onKeyUp={onKeyUpHandler} />
+      </div>,
+    );
+    expect(wrapper).toMatchSnapshot();
+
+    const icon1 = wrapper.find('span').at(0);
+    icon1.simulate('click');
+    expect(onClickHandler).toBeCalledTimes(1);
+
+    const icon2 = wrapper.find('span').at(2);
+    icon2.simulate('mouseenter');
+    expect(onMouseEnterHandler).toBeCalledTimes(1);
+
+    const icon3 = wrapper.find('span').at(3);
+    icon3.simulate('keyup');
+    expect(onKeyUpHandler).toBeCalledTimes(1);
+  });
+
+  it('extraCommonProps should works fine and can be overwritten', () => {
+    const wrapper = render(
+      <div className="icons-list">
+        <IconFont type="icon-tuichu" className="bcd" />
+        <IconFont type="icon-facebook" />
+        <IconFont type="icon-twitter" className="efg" />
+      </div>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should support wrapped by Tooltip', () => {
+    const onVisibleChange = jest.fn();
+    const wrapper = mount(
+      <Tooltip
+        title="xxxxx"
+        mouseEnterDelay={0}
+        mouseLeaveDelay={0}
+        onVisibleChange={onVisibleChange}
+      >
+        <IconFont type="icon-facebook" />
+      </Tooltip>,
+    );
+    expect(wrapper.find('span')).toHaveLength(1);
+    const icon = wrapper.find('span').at(0);
+    icon.simulate('mouseenter');
+    expect(onVisibleChange).toHaveBeenCalledWith(true);
+    expect((wrapper.instance() as any).tooltip.props.visible).toBe(true);
+
+    icon.simulate('mouseleave');
+    expect(onVisibleChange).toHaveBeenCalledWith(false);
+    expect((wrapper.instance() as any).tooltip.props.visible).toBe(false);
+  });
+
+  const IconFont2 = createFromIconfontCN({
+    scriptUrl: ['//at.alicdn.com/t/font_xxx.js', '//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js'],
+    extraCommonProps: {
+      className: 'abc',
+    },
+  });
+
+  it('should support ignore load error', () => {
+    const wrapper = render(<IconFont2 type="icon-facebook" />);
+    expect(wrapper).toMatchSnapshot();
+  })
+
+});

--- a/packages/icons-vue/examples/use-iconfontcn.jsx
+++ b/packages/icons-vue/examples/use-iconfontcn.jsx
@@ -3,7 +3,7 @@ import { createFromIconfontCN } from '../src';
 
 const IconFont = createFromIconfontCN({
   scriptUrl: '//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js',
-  // scriptUrls: ['//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js'],
+  // scriptUrl: ['//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js'],
 });
 
 const SimpleDemo = {

--- a/packages/icons-vue/examples/use-iconfontcn.jsx
+++ b/packages/icons-vue/examples/use-iconfontcn.jsx
@@ -3,6 +3,7 @@ import { createFromIconfontCN } from '../src';
 
 const IconFont = createFromIconfontCN({
   scriptUrl: '//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js',
+  // scriptUrls: ['//at.alicdn.com/t/font_8d5l8fzk5b87iudi.js'],
 });
 
 const SimpleDemo = {

--- a/packages/icons-vue/src/components/IconFont.jsx
+++ b/packages/icons-vue/src/components/IconFont.jsx
@@ -9,12 +9,20 @@ function isValidCustomScriptUrl(scriptUrl) {
     !customCache.has(scriptUrl);
 }
 
-function createScriptUrlElement(scriptUrl) {
-  const script = document.createElement('script');
-  script.setAttribute('src', scriptUrl);
-  script.setAttribute('data-namespace', scriptUrl);
-  customCache.add(scriptUrl);
-  document.body.appendChild(script);
+function createScriptUrlElements(scriptUrls, index = 0) {
+  const currentScriptUrl = scriptUrls[index];
+  if (isValidCustomScriptUrl(currentScriptUrl)) {
+    const script = document.createElement('script');
+    script.setAttribute('src', currentScriptUrl);
+    script.setAttribute('data-namespace', currentScriptUrl);
+    if (scriptUrls.length > index + 1) {
+      script.onload = script.onerror = () => {
+        createScriptUrlElements(scriptUrls, index + 1);
+      }
+    }
+    customCache.add(currentScriptUrl);
+    document.body.appendChild(script);
+  }
 }
 
 export default function create(options = {}) {
@@ -31,15 +39,11 @@ export default function create(options = {}) {
     typeof window !== 'undefined' &&
     typeof document.createElement === 'function'
   ) {
-    if (isValidCustomScriptUrl(scriptUrl)) {
-      createScriptUrlElement(scriptUrl);
-    }
-    if (Array.isArray(scriptUrls)) {
-      scriptUrls.forEach(url => {
-        if (isValidCustomScriptUrl(url)) {
-          createScriptUrlElement(url);
-        }
-      })
+    if (Array.isArray(scriptUrl)) {
+      // 因为iconfont资源会把svg插入before，所以前加载相同type会覆盖后加载，为了数组覆盖顺序，倒叙插入
+      createScriptUrlElements(scriptUrl.reverse());
+    } else {
+      createScriptUrlElements([scriptUrl]);
     }
   }
 

--- a/packages/icons-vue/src/components/IconFont.jsx
+++ b/packages/icons-vue/src/components/IconFont.jsx
@@ -3,6 +3,20 @@ import { mergeProps } from '../utils';
 
 const customCache = new Set();
 
+function isValidCustomScriptUrl(scriptUrl) {
+  return typeof scriptUrl === 'string' &&
+    scriptUrl.length &&
+    !customCache.has(scriptUrl);
+}
+
+function createScriptUrlElement(scriptUrl) {
+  const script = document.createElement('script');
+  script.setAttribute('src', scriptUrl);
+  script.setAttribute('data-namespace', scriptUrl);
+  customCache.add(scriptUrl);
+  document.body.appendChild(script);
+}
+
 export default function create(options = {}) {
   const { scriptUrl, extraCommonProps = {} } = options;
 
@@ -15,16 +29,18 @@ export default function create(options = {}) {
   if (
     typeof document !== 'undefined' &&
     typeof window !== 'undefined' &&
-    typeof document.createElement === 'function' &&
-    typeof scriptUrl === 'string' &&
-    scriptUrl.length &&
-    !customCache.has(scriptUrl)
+    typeof document.createElement === 'function'
   ) {
-    const script = document.createElement('script');
-    script.setAttribute('src', scriptUrl);
-    script.setAttribute('data-namespace', scriptUrl);
-    customCache.add(scriptUrl);
-    document.body.appendChild(script);
+    if (isValidCustomScriptUrl(scriptUrl)) {
+      createScriptUrlElement(scriptUrl);
+    }
+    if (Array.isArray(scriptUrls)) {
+      scriptUrls.forEach(url => {
+        if (isValidCustomScriptUrl(url)) {
+          createScriptUrlElement(url);
+        }
+      })
+    }
   }
 
   const Iconfont = {

--- a/packages/icons-vue/src/components/IconFont.jsx
+++ b/packages/icons-vue/src/components/IconFont.jsx
@@ -16,9 +16,12 @@ function createScriptUrlElements(scriptUrls, index = 0) {
     script.setAttribute('src', currentScriptUrl);
     script.setAttribute('data-namespace', currentScriptUrl);
     if (scriptUrls.length > index + 1) {
-      script.onload = script.onerror = () => {
+      script.onload = () => {
         createScriptUrlElements(scriptUrls, index + 1);
-      }
+      };
+      script.onerror = () => {
+        createScriptUrlElements(scriptUrls, index + 1);
+      };
     }
     customCache.add(currentScriptUrl);
     document.body.appendChild(script);


### PR DESCRIPTION
某些场景需要在项目统一创建iconfont资源的Icon给各个开发者使用，而资源会来自不同iconfont项目，增加可以引入多个iconfont资源的scriptUrls参数，有利于解决这种场景需求，同时也增加了设计师在iconfont管理资源的灵活性。