### PR TITLE
Give IconFont component a chance to get type hints

### DIFF
--- a/packages/icons-react/src/components/IconFont.tsx
+++ b/packages/icons-react/src/components/IconFont.tsx
@@ -8,8 +8,8 @@ export interface CustomIconOptions {
   extraCommonProps?: { [key: string]: any };
 }
 
-export interface IconFontProps extends IconBaseProps {
-  type: string;
+export interface IconFontProps<T extends string = string> extends IconBaseProps {
+  type: T;
 }
 
 function isValidCustomScriptUrl(scriptUrl: string): boolean {
@@ -39,7 +39,9 @@ function createScriptUrlElements(scriptUrls: string[], index: number = 0): void 
   }
 }
 
-export default function create(options: CustomIconOptions = {}): React.SFC<IconFontProps> {
+export default function create<T extends string = string>(
+  options: CustomIconOptions = {}
+): React.SFC<IconFontProps<T>> {
   const { scriptUrl, extraCommonProps = {} } = options;
 
   /**
@@ -62,7 +64,7 @@ export default function create(options: CustomIconOptions = {}): React.SFC<IconF
     }
   }
 
-  const Iconfont = React.forwardRef<HTMLSpanElement, IconFontProps>((props, ref) => {
+  const Iconfont = React.forwardRef<HTMLSpanElement, IconFontProps<T>>((props, ref) => {
     const { type, children, ...restProps } = props;
 
     // children > type

--- a/packages/icons-react/src/components/IconFont.tsx
+++ b/packages/icons-react/src/components/IconFont.tsx
@@ -41,7 +41,7 @@ function createScriptUrlElements(scriptUrls: string[], index: number = 0): void 
 
 export default function create<T extends string = string>(
   options: CustomIconOptions = {}
-): React.SFC<IconFontProps<T>> {
+): React.FC<IconFontProps<T>> {
   const { scriptUrl, extraCommonProps = {} } = options;
 
   /**


### PR DESCRIPTION
### What kind of change does this PR introduce?

Typescript definition update

### What is the current behavior?

Unable to provide friendly type hints.

### What is the new behavior?

Prompt according to the type passed, It's usually a union type.

![type-tips](https://user-images.githubusercontent.com/58550322/90218544-ac632380-de36-11ea-9f1b-cc28eef6cb30.png)

### Does this introduce a breaking change?

No