### PR TITLE
Added esm entry points for icons.

### DIFF
--- a/packages/icons-react/scripts/generate.ts
+++ b/packages/icons-react/scripts/generate.ts
@@ -103,6 +103,12 @@ async function generateEntries() {
       }),
     );
 
+    // generate esm module entries
+    await writeFile(
+      path.resolve(__dirname, `../${svgIdentifier}.mjs`),
+      template(`export { default } from './es/icons/<%= svgIdentifier %>';`)({ svgIdentifier }),
+    );
+
     // generate `Icon.d.ts` in root folder
     await writeFile(
       path.resolve(__dirname, `../${svgIdentifier}.d.ts`),


### PR DESCRIPTION
Added esm entry points for icons.

Fixes following issues in antd: https://github.com/ant-design/ant-design/issues/26226 and https://github.com/ant-design/ant-design/issues/26237.

Problem was in antd importing icons as:
```import DoubleLeftOutlined from '@ant-design/icons/DoubleLeftOutlined';```
which didn't work for esm modules, since there was only primary esm entrypoint (es/index.js) and bundler couldn't find modules in given location.

This PR adds code for generation of es entry points for all icons (mjs files). This in turn enables above imports also in ES modules.
