### PR TITLE
Deduplicate ant-design/colors package by updating antd colors library to match antd main lib

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/icons",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "main": "./lib/index.js",
   "module": "./es/index.js",
   "unpkg": "./dist/index.umd.js",
@@ -60,7 +60,7 @@
     "typescript": "^3.0.3"
   },
   "dependencies": {
-    "@ant-design/colors": "^3.1.0",
+    "@ant-design/colors": "^4.0.5",
     "@ant-design/icons-svg": "^4.0.0",
     "@babel/runtime": "^7.10.4",
     "classnames": "^2.2.6",


### PR DESCRIPTION
When using antd in a react application, I get a duplicated antd-colors package
![image](https://user-images.githubusercontent.com/1418446/96001805-b904f780-0e38-11eb-8a87-47f1d5e5a4bb.png)

This is what the duplication of ant-design/colors package adds to the bundle
![image](https://user-images.githubusercontent.com/1418446/96002336-4a746980-0e39-11eb-8088-65c207fbf0da.png)

I saw the storybooks, looks ok. Tested this change and it seems fine. I didn't see it brake anything