### PR TITLE
Update package.json - react peer dep version

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -31,7 +31,7 @@
     "postcompile": "npm run clean && TS_NODE_PROJECT=scripts/tsconfig.json node -r ts-node/register scripts/generate.ts --target=entry"
   },
   "peerDependencies": {
-    "react": "16.x"
+    "react": "16.x" || "17.x"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.9",


### PR DESCRIPTION
Due to npm 7 auto installing peer dependencies, this has caused incompatibilities with the newly released react 17.x. npm can't resolve a dependency tree if you list react 17.x in your projects dependencies because @ant-design/icons lists 16.x as a peerDep.

I've manually installed @ant-design/icons on react 17 and they seem to work perfectly fine.