### PR TITLE
Fix issue with NPM 7 throwing error

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -31,7 +31,7 @@
     "postcompile": "npm run clean && TS_NODE_PROJECT=scripts/tsconfig.json node -r ts-node/register scripts/generate.ts --target=entry"
   },
   "peerDependencies": {
-    "react": "16.x"
+    "react": ">= 16.x"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.9",


### PR DESCRIPTION
NPM 7 automatically installs peer dependencies. Trying to update to React 17 causes error when installing ```@ant-design/icons```
More info here: https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/

Based on the advice from Kent C. Dodds and Cory House, I updated peer dependency of React to be ">= 16.x"
Tweets: https://mobile.twitter.com/kentcdodds/status/1325565636303482880