### PR TITLE
fix(icons-rn):auto link fonts file assets

### DIFF
--- a/packages/icons-react-native/package.json
+++ b/packages/icons-react-native/package.json
@@ -28,7 +28,8 @@
   "files": [
     "es",
     "lib",
-    "fonts"
+    "fonts",
+    "react-native.config.js"
   ],
   "peerDependencies": {
     "react": "16.x"

--- a/packages/icons-react-native/react-native.config.js
+++ b/packages/icons-react-native/react-native.config.js
@@ -1,7 +1,5 @@
 module.exports = {
-  project: {
-    ios: {},
-    android: {}
-  },
-  assets: ["./fonts"]
+  dependency: {
+    assets: ['fonts']
+  }
 };


### PR DESCRIPTION
单独使用`@ant-design/icons-react-native`时需要link字体文件到原生项目中

npm发布时请将`react-native.config.js`也携带发布上