### PR TITLE
feat: Icon support prefixCls config

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -52,6 +52,7 @@
     "lodash": "^4.17.15",
     "mobx": "^5.1.0",
     "mobx-react": "^6.1.3",
+    "prettier": "^2.2.1",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "rimraf": "^3.0.0",

--- a/packages/icons-react/src/components/AntdIcon.tsx
+++ b/packages/icons-react/src/components/AntdIcon.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import type { IconDefinition } from '@ant-design/icons-svg/lib/types';
 
+import Context from './Context';
 import type { IconBaseProps } from './Icon';
 import ReactIcon from './IconBase';
 import { getTwoToneColor, TwoToneColor, setTwoToneColor } from './twoTonePrimaryColor';
@@ -20,9 +21,8 @@ export interface IconComponentProps extends AntdIconProps {
 setTwoToneColor('#1890ff');
 
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34757#issuecomment-488848720
-interface IconBaseComponent<Props> extends React.ForwardRefExoticComponent<
-  Props & React.RefAttributes<HTMLSpanElement>
-> {
+interface IconBaseComponent<Props>
+  extends React.ForwardRefExoticComponent<Props & React.RefAttributes<HTMLSpanElement>> {
   getTwoToneColor: typeof getTwoToneColor;
   setTwoToneColor: typeof setTwoToneColor;
 }
@@ -46,10 +46,14 @@ const Icon = React.forwardRef<HTMLSpanElement, IconComponentProps>((props, ref) 
     ...restProps
   } = props;
 
+  const { prefixCls = 'anticon' } = React.useContext(Context);
+
   const classString = classNames(
-    'anticon',
-    { [`anticon-${icon.name}`]: Boolean(icon.name) },
-    { 'anticon-spin': !!spin || icon.name === 'loading' },
+    prefixCls,
+    {
+      [`${prefixCls}-${icon.name}`]: !!icon.name,
+      [`${prefixCls}-spin`]: !!spin || icon.name === 'loading',
+    },
     className,
   );
 
@@ -60,9 +64,9 @@ const Icon = React.forwardRef<HTMLSpanElement, IconComponentProps>((props, ref) 
 
   const svgStyle = rotate
     ? {
-      msTransform: `rotate(${rotate}deg)`,
-      transform: `rotate(${rotate}deg)`,
-    }
+        msTransform: `rotate(${rotate}deg)`,
+        transform: `rotate(${rotate}deg)`,
+      }
     : undefined;
 
   const [primaryColor, secondaryColor] = normalizeTwoToneColors(twoToneColor);

--- a/packages/icons-react/src/components/Context.tsx
+++ b/packages/icons-react/src/components/Context.tsx
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+export interface IconContextProps {
+  prefixCls?: string;
+}
+
+const IconContext = createContext<IconContextProps>({});
+
+export default IconContext;

--- a/packages/icons-react/src/index.ts
+++ b/packages/icons-react/src/index.ts
@@ -1,4 +1,9 @@
+import Context from './components/Context';
+
 export * from './icons';
 export * from './components/twoTonePrimaryColor';
 export { default as createFromIconfontCN } from './components/IconFont';
 export { default } from './components/Icon';
+
+const IconProvider = Context.Provider;
+export { IconProvider };

--- a/packages/icons-react/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/icons-react/tests/__snapshots__/index.test.tsx.snap
@@ -1298,3 +1298,25 @@ exports[`Icon.createFromIconfontCN({scriptUrl:[]}) should support ignore load er
   </svg>
 </span>
 `;
+
+exports[`Icon.createFromIconfontCN({scriptUrl:[]}) should support provider 1`] = `
+<span
+  aria-label="home"
+  class="bamboo bamboo-home light"
+  role="img"
+>
+  <svg
+    aria-hidden="true"
+    data-icon="home"
+    fill="currentColor"
+    focusable="false"
+    height="1em"
+    viewBox="64 64 896 896"
+    width="1em"
+  >
+    <path
+      d="M946.5 505L560.1 118.8l-25.9-25.9a31.5 31.5 0 00-44.4 0L77.5 505a63.9 63.9 0 00-18.8 46c.4 35.2 29.7 63.3 64.9 63.3h42.5V940h691.8V614.3h43.4c17.1 0 33.2-6.7 45.3-18.8a63.6 63.6 0 0018.7-45.3c0-17-6.7-33.1-18.8-45.2zM568 868H456V664h112v204zm217.9-325.7V868H632V640c0-22.1-17.9-40-40-40H432c-22.1 0-40 17.9-40 40v228H238.1V542.3h-96l370-369.7 23.1 23.1L882 542.3h-96.1z"
+    />
+  </svg>
+</span>
+`;

--- a/packages/icons-react/tests/index.test.tsx
+++ b/packages/icons-react/tests/index.test.tsx
@@ -2,9 +2,17 @@ import { Tooltip } from 'antd';
 import * as React from 'react';
 import { render, mount } from 'enzyme';
 import Icon, {
-  getTwoToneColor, setTwoToneColor, createFromIconfontCN,
-  HomeOutlined, SettingFilled, SmileOutlined, SyncOutlined,
-  LoadingOutlined, CheckCircleTwoTone, ClockCircleOutlined,
+  getTwoToneColor,
+  setTwoToneColor,
+  createFromIconfontCN,
+  HomeOutlined,
+  SettingFilled,
+  SmileOutlined,
+  SyncOutlined,
+  LoadingOutlined,
+  CheckCircleTwoTone,
+  ClockCircleOutlined,
+  IconProvider,
 } from '../lib';
 import { getSecondaryColor } from '../src/utils';
 
@@ -119,7 +127,8 @@ describe('Icon', () => {
         viewBox="0 0 24 24"
         onClick={onClickHandler}
         onKeyUp={onKeyUpHandler}
-        onMouseEnter={onMouseEnterHandler}>
+        onMouseEnter={onMouseEnterHandler}
+      >
         <title>Cool Home</title>
         <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
       </Icon>,
@@ -169,7 +178,7 @@ describe('Icon', () => {
     const renderSvg = () => (
       <svg viewBox="0 0 1024 1024" width="1em" height="1em" fill="currentColor" />
     );
-    const SvgIcon = props => <Icon component={renderSvg} {...props} />;
+    const SvgIcon = (props) => <Icon component={renderSvg} {...props} />;
 
     expect(mount(<SvgIcon />).render()).toMatchSnapshot();
   });
@@ -195,7 +204,7 @@ describe('Icon', () => {
       const wrapper = render(
         <Icon
           className="my-home-icon"
-          component={svgProps => (
+          component={(svgProps) => (
             <svg {...svgProps}>
               <defs>
                 <linearGradient id="gradient">
@@ -222,7 +231,7 @@ describe('Icon', () => {
 
   it('should support svg react component', () => {
     // children props would make no sense
-    const SvgComponent = props => (
+    const SvgComponent = (props) => (
       <svg viewBox="0 0 24 24" {...props}>
         <title>Custom Svg</title>
         <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -243,7 +252,7 @@ describe('Icon', () => {
     const onKeyUpHandler = jest.fn();
     const onMouseEnterHandler = jest.fn();
     // children props would make no sense
-    const SvgComponent = props => (
+    const SvgComponent = (props) => (
       <svg viewBox="0 0 24 24" {...props}>
         <title>Custom Svg</title>
         <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -256,7 +265,8 @@ describe('Icon', () => {
         component={SvgComponent}
         onClick={onClickHandler}
         onKeyUp={onKeyUpHandler}
-        onMouseEnter={onMouseEnterHandler}>
+        onMouseEnter={onMouseEnterHandler}
+      >
         <title>Cool Home</title>
         <path d="'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z'" />
       </Icon>,
@@ -444,6 +454,14 @@ describe('Icon.createFromIconfontCN({scriptUrl:[]})', () => {
   it('should support ignore load error', () => {
     const wrapper = render(<IconFont2 type="icon-facebook" />);
     expect(wrapper).toMatchSnapshot();
-  })
+  });
 
+  it('should support provider', () => {
+    const wrapper = render(
+      <IconProvider value={{ prefixCls: 'bamboo' }}>
+        <HomeOutlined className="light" />
+      </IconProvider>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
暂时只开一个 ContextProvider，不允许单独设置。云凤蝶那边有 3、4 混用的情况，`anticon` 会导致样式混乱，要分一分。