### PR TITLE
fix: remove postinstall from scripts

### DIFF
--- a/packages/icons-react-native/package.json
+++ b/packages/icons-react-native/package.json
@@ -21,7 +21,6 @@
     "pregenerate": "npm run clean",
     "clean": "rimraf -rf fonts iconfont src/*.tsx",
     "prepublishOnly": "npm run lint && npm run test && npm run compile",
-    "postinstall": "npm run patch-package",
     "patch-package": "patch-package",
     "ci": "npm run lint && npm run test && npm run compile"
   },


### PR DESCRIPTION
https://github.com/ant-design/ant-design-icons/issues/484