### PR TITLE
fix(icons-react): add react-dom to peerDependencies

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -31,7 +31,8 @@
     "postcompile": "npm run clean && TS_NODE_PROJECT=scripts/tsconfig.json node -r ts-node/register scripts/generate.ts --target=entry"
   },
   "peerDependencies": {
-    "react": ">=16.0.0"
+    "react": ">=16.0.0",
+    "react-dom": ">=16.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.9",


### PR DESCRIPTION
```
➤ YN0000: ┌ Resolution step
➤ YN0002: │ @ant-design/icons@npm:4.6.2 [03b60] doesn't provide react-dom (p405f2), requested by rc-util
➤ YN0002: │ @ant-design/icons@npm:4.6.2 [daa27] doesn't provide react-dom (p0a8fb), requested by rc-util
```

[rc-util request react-dom as peerDependencies](https://github.com/react-component/util/blob/88be0cbf06d5190d5baa21fcfa9b36977a3796fd/package.json#L55)