### PR TITLE
fix(typescript): component prop supports ForwardRefExoticComponent

### DIFF
--- a/packages/icons-react/src/components/Icon.tsx
+++ b/packages/icons-react/src/components/Icon.tsx
@@ -16,10 +16,9 @@ export interface CustomIconComponentProps {
   className?: string;
   style?: React.CSSProperties;
 }
-
 export interface IconComponentProps extends IconBaseProps {
   viewBox?: string;
-  component?: React.ComponentType<CustomIconComponentProps | React.SVGProps<SVGSVGElement>>;
+  component?: React.ComponentType<CustomIconComponentProps | React.SVGProps<SVGSVGElement>> | React.ForwardRefExoticComponent<CustomIconComponentProps>;
   ariaLabel?: React.AriaAttributes['aria-label'];
 }
 


### PR DESCRIPTION
package: icons-react

Issue: https://github.com/ant-design/ant-design/issues/27735 the prop "component" of Icon can not accept ref foward component

Reason: @types/react separates ExoticComponent and ComponentType. ForwardRefExoticComponent extends ExoticComponent, need be attached.

---

package: icons-react

Issue: https://github.com/ant-design/ant-design/issues/27735 Icon 组件的 component 属性无法接受经过 ref 转发的组件

reason: @types/react 将 ExoticComponent 和 ComponentType 两个类型分隔开，两者没有继承关系，ForwardRefExoticComponent 继承自 ExoticComponent。因此需要附加上 ForwardRefExoticComponent。

---
close https://github.com/ant-design/ant-design-icons/pull/432
close https://github.com/ant-design/ant-design/issues/27735