### PR TITLE
Pick 导致属性报错

### DIFF
--- a/packages/icons-react/src/components/Icon.tsx
+++ b/packages/icons-react/src/components/Icon.tsx
@@ -7,6 +7,7 @@ import { svgBaseProps, warning, useInsertStyles } from '../utils';
 export interface IconBaseProps extends React.HTMLProps<HTMLSpanElement> {
   spin?: boolean;
   rotate?: number;
+	translate?: string;
 }
 
 export interface CustomIconComponentProps {

--- a/packages/icons-react/src/components/Icon.tsx
+++ b/packages/icons-react/src/components/Icon.tsx
@@ -7,7 +7,7 @@ import { svgBaseProps, warning, useInsertStyles } from '../utils';
 export interface IconBaseProps extends React.HTMLProps<HTMLSpanElement> {
   spin?: boolean;
   rotate?: number;
-	translate?: string;
+  translate?: string;
 }
 
 export interface CustomIconComponentProps {


### PR DESCRIPTION
react 16. 13 以下的版本会报错。
Pick 属性的时候，不能在 React.ComponentType<CustomIconComponentProps | React.SVGProps<SVGSVGElement>>; 中，找到translate，需要每个图标自己添加。否则 TSlLint报错。
鼠标滚轮 onAuxClick, onAuxClickCapture 也有类似的问题，需要更新或修改  @types/react/index.d.ts  这个可以说是react版本问题。