### PR TITLE
style: fix the content vertical-align issue

### DIFF
--- a/packages/icons-react/src/utils.ts
+++ b/packages/icons-react/src/utils.ts
@@ -104,6 +104,7 @@ export const iconStyles = `
 }
 
 .anticon svg {
+  vertical-align: initial;
   display: inline-block;
 }
 

--- a/packages/icons-vue/src/utils.ts
+++ b/packages/icons-vue/src/utils.ts
@@ -112,6 +112,7 @@ export const iconStyles = `
 }
 
 .anticon svg {
+  vertical-align: initial;
   display: inline-block;
 }
 


### PR DESCRIPTION
If using a third-party icon package like @fortawesome, the content and icon will not vertical-align issue

related issue [# ant-design 33216](https://github.com/ant-design/ant-design/issues/33216)