### PR TITLE
fix: node.insertBefore parameter issue

### DIFF
--- a/packages/icons-vue/src/insert-css.ts
+++ b/packages/icons-vue/src/insert-css.ts
@@ -42,11 +42,8 @@ function insertCss(css: any, options: any): any {
   } else {
     styleElement = styleElements[containerId][position] = createStyleElement();
 
-    if (position === 'prepend') {
-      container.insertBefore(styleElement, container.childNodes[0]);
-    } else {
-      container.appendChild(styleElement);
-    }
+    const referenceNode = position === 'prepend' ? container.childNodes[0] || null : null
+    container.insertBefore(styleElement, referenceNode);
   }
 
   // strip potential UTF-8 BOM if css was read from a file


### PR DESCRIPTION
## Root Cause
According to [insertBefore API doc](https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore):
> Note: referenceNode is not an optional parameter. You must explicitly pass a Node or null.

so we have to pass `null`, if `referenceNode` is `undefined` for 2nd parameter.

## References:
#### 1.  `insertBefore` equals `appendChild` when `referenceNode` is null, [refer to Vue source code](https://github.com/vuejs/core/pull/1463/commits/9e0fc6cd083083be662f3d03845b544471d69d2f)
![image](https://user-images.githubusercontent.com/7044628/191460171-d88b6574-d0e8-4a01-a7a9-b9add2307c4c.png)

#### 2. In Chrome, Firefox, Safari, it works when `referenceNode` is `undefined`, the same as `null` dose.
But `happy-dom` doesn't, it is strict as API said. [check this code](https://github.com/capricorn86/happy-dom/blob/f7c8a895beb09067ac77e0074d4c306162aa14ae/packages/happy-dom/src/nodes/node/Node.ts#L369)

![image](https://user-images.githubusercontent.com/7044628/191460488-e25d52e2-233e-4c68-9d5e-7f6c100b9e2b.png)


#### 3. An [issue](https://github.com/vueComponent/ant-design-vue/issues/5927) in ant-design-vue was caused by this.