### PR TITLE
build(react): correct umd exports

### DIFF
--- a/packages/icons-react/.fatherrc.js
+++ b/packages/icons-react/.fatherrc.js
@@ -7,6 +7,7 @@ const config = {
 
 if (process.env.NODE_ENV !== 'ci') {
   config.umd = {
+    name: 'icons',
     externals: { react: 'React' },
     sourcemap: false,
   };


### PR DESCRIPTION
修正 `@ant-design/icons` UMD 产物构建的导出配置，将所有图标暴露在 `window.icons` 上。

Close #574 