### PR TITLE
fix(plus-outlined): increase width of horizontal bar to match height of vertical bar

### DIFF
--- a/packages/icons-svg/svg/outlined/plus.svg
+++ b/packages/icons-svg/svg/outlined/plus.svg
@@ -1,1 +1,5 @@
-<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg t="1551322312294" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="10297" xmlns:xlink="http://www.w3.org/1999/xlink" width="200" height="200"><defs><style type="text/css"></style></defs><path d="M474 152m8 0l60 0q8 0 8 8l0 704q0 8-8 8l-60 0q-8 0-8-8l0-704q0-8 8-8Z" p-id="10298"></path><path d="M168 474m8 0l672 0q8 0 8 8l0 60q0 8-8 8l-672 0q-8 0-8-8l0-60q0-8 8-8Z" p-id="10299"></path></svg>
+<?xml version="1.0" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" class="icon" viewBox="0 0 1024 1024">
+    <path d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8Z"/>
+    <path d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8Z"/>
+</svg>


### PR DESCRIPTION
This PR increases the width of the horizontal bar to match the height of the vertical bar in the plus icon.

While at it, I also cleaned up the SVG to match the other SVGs.


Previously, the plus icon's bounding box was not a square:
![image](https://github.com/ant-design/ant-design-icons/assets/44374653/be76c30c-9548-489c-b99d-f355b5406033)
The original icon superimposed onto itself when rotated 90°. 

As you can see, the length of the two lines were not the same. This is especially noticeable when the icon is rendered at smaller sizes, where browsers start aligning the rasterized SVG to pixels.
Before:
![image](https://github.com/ant-design/ant-design-icons/assets/44374653/9fce740b-5e4c-474d-af65-7e5b23d733b4)
After:
![image](https://github.com/ant-design/ant-design-icons/assets/44374653/ef2cd6c1-7457-47af-9e17-62b5c672b3d2)

---


Please let me know if I need to run any build scripts.