### PR TITLE
chore: using swc instead of esbuild to fix tree shaking that doesn't work

### DIFF
--- a/packages/icons-react/.fatherrc.js
+++ b/packages/icons-react/.fatherrc.js
@@ -1,9 +1,18 @@
 import { defineConfig } from 'father';
 
-const config = {
+
+
+
+const config = defineConfig({
   // Locked version only supports 1.0.0
   plugins: ['@rc-component/father-plugin'],
-};
+  esm: {
+    transformer: 'swc',
+  },
+  cjs: {
+    transformer: 'swc',
+  }
+});
 
 if (process.env.NODE_ENV !== 'ci') {
   config.umd = {
@@ -33,4 +42,4 @@ if (process.env.NODE_ENV !== 'ci') {
   };
 }
 
-export default defineConfig(config);
+export default config;

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -70,7 +70,8 @@
     "rimraf": "^3.0.0",
     "styled-components": "^3.3.3",
     "ts-node": "^8.0.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.2",
+    "@swc/core": "^1.3.53"
   },
   "peerDependencies": {
     "react": ">=16.0.0",

--- a/packages/icons-react/scripts/generate.ts
+++ b/packages/icons-react/scripts/generate.ts
@@ -82,18 +82,18 @@ ${entryText}
 async function generateEntries() {
   const render = template(`
 'use strict';
-  Object.defineProperty(exports, "__esModule", {
-    value: true
-  });
-  exports.default = void 0;
-  
-  var _<%= svgIdentifier %> = _interopRequireDefault(require('./lib/icons/<%= svgIdentifier %>'));
-  
-  function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-  
-  var _default = _<%= svgIdentifier %>;
-  exports.default = _default;
-  module.exports = _default;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+const _<%= svgIdentifier %> = _interopRequireDefault(require('./lib/icons/<%= svgIdentifier %>'));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+const _default = _<%= svgIdentifier %>;
+exports.default = _default;
+module.exports = _default;
 `.trim());
 
   await walk(async ({ svgIdentifier }) => {


### PR DESCRIPTION
### 原因
由于最终使用 `esbuild` 构建，而 `esbuild` 有 [top-level-var](https://esbuild.github.io/faq/#top-level-var) 的问题，将会把打包的产物中的 `const` 和`let` 转为 `var`，因此 tree shaking 发现如果一个变量是以 `var` 声明的会认为这个变量包含 side effect，所以将不会对其进行 tree shaking。

### 解决方案
1. 将 `transformer` 设置为 `swc`
2. 将生成的代码中包含的 `var` 改写成 `const`