### PR TITLE
chore: use lodash instead of lodash.camelcase

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -32,7 +32,7 @@
     "@ant-design/icons-svg": "^4.3.0",
     "@babel/runtime": "^7.11.2",
     "classnames": "^2.2.6",
-    "lodash.camelcase": "^4.3.0",
+    "lodash": "^4.17.21",
     "rc-util": "^5.31.1"
   },
   "devDependencies": {

--- a/packages/icons-react/src/utils.ts
+++ b/packages/icons-react/src/utils.ts
@@ -1,6 +1,6 @@
 import { generate as generateColor } from '@ant-design/colors';
 import type { AbstractNode, IconDefinition } from '@ant-design/icons-svg/lib/types';
-import camelCase from 'lodash.camelcase';
+import camelCase from 'lodash/camelcase';
 import { updateCSS } from 'rc-util/lib/Dom/dynamicCSS';
 import { getShadowRoot } from 'rc-util/lib/Dom/shadow';
 import warn from 'rc-util/lib/warning';

--- a/packages/icons-react/src/utils.ts
+++ b/packages/icons-react/src/utils.ts
@@ -1,6 +1,6 @@
 import { generate as generateColor } from '@ant-design/colors';
 import type { AbstractNode, IconDefinition } from '@ant-design/icons-svg/lib/types';
-import camelCase from 'lodash/camelcase';
+import camelCase from 'lodash/camelCase';
 import { updateCSS } from 'rc-util/lib/Dom/dynamicCSS';
 import { getShadowRoot } from 'rc-util/lib/Dom/shadow';
 import warn from 'rc-util/lib/warning';


### PR DESCRIPTION
`generate.ts` 中也使用了 `lodash`，之前去掉 `lodash` 的依赖导致幽灵依赖了，改回去。