### PR TITLE
perf: remove lodash/camelCase for smaller bundle size

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -32,7 +32,6 @@
     "@ant-design/icons-svg": "^4.3.0",
     "@babel/runtime": "^7.11.2",
     "classnames": "^2.2.6",
-    "lodash": "^4.17.21",
     "rc-util": "^5.31.1"
   },
   "devDependencies": {

--- a/packages/icons-react/src/utils.ts
+++ b/packages/icons-react/src/utils.ts
@@ -1,11 +1,14 @@
 import { generate as generateColor } from '@ant-design/colors';
 import type { AbstractNode, IconDefinition } from '@ant-design/icons-svg/lib/types';
-import camelCase from 'lodash/camelCase';
 import { updateCSS } from 'rc-util/lib/Dom/dynamicCSS';
 import { getShadowRoot } from 'rc-util/lib/Dom/shadow';
 import warn from 'rc-util/lib/warning';
 import React, { useContext, useEffect } from 'react';
 import IconContext from './components/Context';
+
+function camelCase(input: string) {
+  return input.replace(/-(.)/g, (match, g) => g.toUpperCase());
+}
 
 export function warning(valid: boolean, message: string) {
   warn(valid, `[@ant-design/icons] ${message}`);


### PR DESCRIPTION
看上去只处理了 fill-rule 转 fillRule 这类情况，单独引用一个包很不划算。

ref: https://github.com/ant-design/ant-design/issues/39900#issuecomment-1697653403