### PR TITLE
fix(icons-vue): twoToneColor supports reactive

### DIFF
--- a/packages/icons-vue/src/components/IconBase.tsx
+++ b/packages/icons-vue/src/components/IconBase.tsx
@@ -1,6 +1,6 @@
 import { generate, getSecondaryColor, isIconDefinition, warning } from '../utils';
 import { AbstractNode, IconDefinition } from '@ant-design/icons-svg/lib/types';
-import { CSSProperties, FunctionalComponent, PropType } from 'vue';
+import { CSSProperties, FunctionalComponent, PropType, reactive } from 'vue';
 
 export interface IconProps {
   icon: IconDefinition;
@@ -21,11 +21,11 @@ export interface TwoToneColorPalette extends TwoToneColorPaletteSetter {
   calculated?: boolean; // marker for calculation
 }
 
-const twoToneColorPalette: TwoToneColorPalette = {
+const twoToneColorPalette: TwoToneColorPalette = reactive({
   primaryColor: '#333',
   secondaryColor: '#E6E6E6',
   calculated: false,
-};
+});
 
 function setTwoToneColors({ primaryColor, secondaryColor }: TwoToneColorPaletteSetter): void {
   twoToneColorPalette.primaryColor = primaryColor;


### PR DESCRIPTION
fixed the issue that when using `setTwoToneColors`, the page template was not updated.

Related issues: [ant-design-vue/issue/6989](https://github.com/vueComponent/ant-design-vue/issues/6989)