### PR TITLE
fix(icons-react): use HTMLAttributes instead of HTMLProps

### DIFF
--- a/packages/icons-react/src/components/Icon.tsx
+++ b/packages/icons-react/src/components/Icon.tsx
@@ -6,7 +6,7 @@ import Context from './Context';
 
 import { svgBaseProps, warning, useInsertStyles } from '../utils';
 
-export interface IconBaseProps extends React.HTMLProps<HTMLSpanElement> {
+export interface IconBaseProps extends React.HTMLAttributes<HTMLSpanElement> {
   spin?: boolean;
   rotate?: number;
 }


### PR DESCRIPTION
related to
* https://github.com/ant-design/ant-design/issues/47886
* https://github.com/ant-design/ant-design-icons/issues/628

-----------------------------------

Reference from gpt-4

React-specific attributes that are included in React.HTMLProps but not in React.HTMLAttributes include:

ref: This is a special attribute that can be used to get a reference to the underlying DOM element or the instance of a class component. It's useful for direct manipulation of DOM elements.

key: This is a special attribute that helps React identify which items have changed, are added, or are removed in lists. It's important for efficient re-rendering of lists.
