### PR TITLE
fix(react): use inline-flex to center icon

### DIFF
--- a/packages/icons-react/src/utils.ts
+++ b/packages/icons-react/src/utils.ts
@@ -99,7 +99,8 @@ export const svgBaseProps = {
 
 export const iconStyles = `
 .anticon {
-  display: inline-block;
+  display: inline-flex;
+  alignItems: center;
   color: inherit;
   font-style: normal;
   line-height: 0;


### PR DESCRIPTION
antd 中有覆盖，为了避免不确定性，改成和 antd 一样的样式