### PR TITLE
fix: import bug in server (next.js/remix/bun)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
   "devDependencies": {
     "lerna": "^3.4.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": "git@github.com:ant-design/ant-design-icons.git"
 }

--- a/packages/icons-react/.fatherrc.js
+++ b/packages/icons-react/.fatherrc.js
@@ -3,12 +3,6 @@ import { defineConfig } from 'father';
 const config = defineConfig({
   // Locked version only supports 1.0.0
   plugins: ['@rc-component/father-plugin'],
-  cjs: {
-    transformer: 'swc',
-    targets: {
-      ie: 11,
-    },
-  },
 });
 
 if (process.env.NODE_ENV !== 'ci') {

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -11,6 +11,10 @@
   "main": "./lib/index.js",
   "unpkg": "./dist/index.umd.js",
   "module": "./es/index.js",
+  "exports": {
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "typings": "./lib/index.d.ts",
   "scripts": {
     "ci": "NODE_ENV=ci npm run prepublishOnly",

--- a/packages/icons-react/src/index.ts
+++ b/packages/icons-react/src/index.ts
@@ -4,6 +4,4 @@ export * from './icons';
 export * from './components/twoTonePrimaryColor';
 export { default as createFromIconfontCN } from './components/IconFont';
 export { default } from './components/Icon';
-
-const IconProvider = Context.Provider;
-export { IconProvider };
+export const IconProvider = Context.Provider;


### PR DESCRIPTION
- close https://github.com/ant-design/ant-design-icons/issues/605
- close https://github.com/ant-design/ant-design-icons/issues/307
- close https://github.com/ant-design/ant-design-icons/issues/651
- close https://github.com/ant-design/ant-design-icons/issues/638
- close https://github.com/ant-design/ant-design-icons/issues/652
- close https://github.com/ant-design/ant-design-icons/issues/619
- close https://github.com/vercel/next.js/issues/65707
- close https://github.com/ant-design/ant-design-icons/issues/589

---

1. 一开始是 @Dunqing 在 https://github.com/ant-design/ant-design-icons/pull/583 ，将 cjs 的编译方式从 esbuild 改成了 swc，从而尝试解决顶层 var 导致 tree-shaking 失效的问题（如 https://github.com/ant-design/ant-design-icons/issues/307 https://github.com/ant-design/ant-design-icons/issues/486）。
2. https://github.com/ant-design/ant-design-icons/pull/583 随即导致了在 node 环境下无法正确引用的问题，cjs 的打包方式改成 swc 后存在问题：https://github.com/ant-design/ant-design-icons/issues/605
3. 后续对 father 配置的两次更新又把 https://github.com/ant-design/ant-design-icons/pull/583 解决掉的问题改回来了：https://github.com/ant-design/ant-design-icons/pull/588 和 https://github.com/ant-design/ant-design-icons/commit/916efcc3cbac7044b6e5508d68e7fff2dae3faf9

因此现在 TreeShaking 也不好使，node 环境下的引用也不好使。

解决方案是先回到 father 的默认编译配置，先把 node 环境下的引用问题解决掉：https://github.com/ant-design/ant-design-icons/issues/605