### PR TITLE
feat: support layer

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/icons",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "repository": "https://github.com/ant-design/ant-design-icons/tree/master/packages/icons-react",
   "license": "MIT",
   "contributors": [

--- a/packages/icons-react/src/components/Context.tsx
+++ b/packages/icons-react/src/components/Context.tsx
@@ -4,6 +4,7 @@ export interface IconContextProps {
   prefixCls?: string;
   rootClassName?: string;
   csp?: { nonce?: string };
+  layer?: string;
 }
 
 const IconContext = createContext<IconContextProps>({});

--- a/packages/icons-react/src/utils.ts
+++ b/packages/icons-react/src/utils.ts
@@ -155,11 +155,15 @@ export const iconStyles = `
 `;
 
 export const useInsertStyles = (eleRef: React.RefObject<HTMLElement>) => {
-  const { csp, prefixCls } = useContext(IconContext);
+  const { csp, prefixCls, layer } = useContext(IconContext);
   let mergedStyleStr = iconStyles;
 
   if (prefixCls) {
     mergedStyleStr = mergedStyleStr.replace(/anticon/g, prefixCls);
+  }
+
+  if (layer) {
+    mergedStyleStr = `@layer ${layer} {\n${mergedStyleStr}\n}`;
   }
 
   useEffect(() => {

--- a/packages/icons-react/tests/index.test.tsx
+++ b/packages/icons-react/tests/index.test.tsx
@@ -512,4 +512,15 @@ describe('Icon.createFromIconfontCN({scriptUrl:[]})', () => {
     const wrapper = render(<CloseCircleFilled />);
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should support layer', () => {
+    testingLibRender(
+      <IconProvider value={{ layer: 'test' }}>
+        <HomeOutlined />
+      </IconProvider>,
+    );
+
+    const styleEle = document.querySelector('style')!;
+    expect(styleEle.innerHTML).toContain('@layer test');
+  });
 });


### PR DESCRIPTION
ref https://github.com/ant-design/ant-design/issues/52506

Icon 比较麻烦的地方在于 antd 修改 CP 会影响所有用到的地方，不过目前看 antd 已经会影响 prefixCls，多一个也无妨。