### PR TITLE
docs: fix typo in README.md filename across all contribution guides

### DIFF
--- a/packages/icons-svg/docs/ContributionGuide.ja-JP.md
+++ b/packages/icons-svg/docs/ContributionGuide.ja-JP.md
@@ -6,7 +6,7 @@
 
 ```bash
 .
-├── ReadMe.md
+├── README.md
 ├── babel.config.cjs      # jestで使用されるbabel設定
 ├── docs
 ├── es                    # TypeScriptコンパイラの出力ディレクトリ（--module esnext）

--- a/packages/icons-svg/docs/ContributionGuide.md
+++ b/packages/icons-svg/docs/ContributionGuide.md
@@ -6,7 +6,7 @@
 
 ```bash
 .
-├── ReadMe.md
+├── README.md
 ├── babel.config.cjs      # babel config used by jest
 ├── docs
 ├── es                    # the output directory of typescript compiler (--module esnext)

--- a/packages/icons-svg/docs/ContributionGuide.zh-CN.md
+++ b/packages/icons-svg/docs/ContributionGuide.zh-CN.md
@@ -6,7 +6,7 @@
 
 ```bash
 .
-├── ReadMe.md
+├── README.md
 ├── babel.config.cjs      # 用于测试环境的 babel 配置
 ├── docs                  # 项目文档
 ├── es                    # tsc 输出目录，使用 ES Modules


### PR DESCRIPTION
This PR fixes a typo in the filename reference "ReadMe.md" → "README.md" in the following contribution guides:

- `ContributionGuide.md` (English) 📖
- `ContributionGuide.ja-JP.md` (Japanese) 🇯🇵
- `ContributionGuide.zh-CN.md` (Simplified Chinese) 🇨🇳

Ensures consistency and prevents confusion for contributors. 🍀
