### PR TITLE
fix(icons-react): center loading icon by removing display:inline-block from .anticon-spin

### DIFF
--- a/packages/icons-react/src/utils.ts
+++ b/packages/icons-react/src/utils.ts
@@ -135,7 +135,6 @@ export const iconStyles = `
   cursor: pointer;
 }
 
-.anticon-spin::before,
 .anticon-spin {
   -webkit-animation: loadingCircle 1s infinite linear;
   animation: loadingCircle 1s infinite linear;

--- a/packages/icons-react/src/utils.ts
+++ b/packages/icons-react/src/utils.ts
@@ -137,7 +137,6 @@ export const iconStyles = `
 
 .anticon-spin::before,
 .anticon-spin {
-  display: inline-block;
   -webkit-animation: loadingCircle 1s infinite linear;
   animation: loadingCircle 1s infinite linear;
 }


### PR DESCRIPTION
## 修复说明

修复 [ant-design/ant-design#56964](https://github.com/ant-design/ant-design/issues/56964)：Button 在 `loading` 状态下图标未居中的问题。

## 原因

V6中 .anticon-spin 的代码会覆盖 .anticon样式；看V5（如图）的demo是没有覆盖的；
<img width="1292" height="725" alt="image" src="https://github.com/user-attachments/assets/90d412b4-dc3a-4b03-8ec0-80aaf4eed9f0" />

<img width="350" height="79" alt="image" src="https://github.com/user-attachments/assets/4e18c0e2-adc7-4e9f-b370-fb67d5208680" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **样式**
  * 调整了加载指示器的显示方式，移除了对其强制内联块布局的设置，使其在不同布局中呈现更自然、兼容性更好，改善了在界面中与周围元素的对齐与排布。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->