### PR TITLE
fix(icons-react): icons export

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -28,6 +28,11 @@
       "import": "./es/components/*.js",
       "require": "./lib/components/*.js"
     },
+    "./es/icons": {
+      "types": "./lib/icons/index.d.ts",
+      "import": "./es/icons/index.js",
+      "require": "./lib/icons/index.js"
+    },
     "./lib/*": {
       "types": "./lib/*.d.ts",
       "import": "./es/*.js",
@@ -37,6 +42,11 @@
       "types": "./lib/components/*.d.ts",
       "import": "./es/components/*.js",
       "require": "./lib/components/*.js"
+    },
+    "./lib/icons": {
+      "types": "./lib/icons/index.d.ts",
+      "import": "./es/icons/index.js",
+      "require": "./lib/icons/index.js"
     },
     "./package.json": "./package.json",
     "./*": {


### PR DESCRIPTION
修复 @ant-design/compatible 兼容

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
  * 更新了 icons-react 包的导出配置，支持通过 `./icons` 子路径导入图标库。现已提供 ES 模块和 CommonJS 两种格式的官方支持，并为两种格式都包含了完整的 TypeScript 类型定义。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->