### PR TITLE
fix(icons-svg): add prepare hook so a clean install builds the package

### DIFF
--- a/packages/icons-svg/package.json
+++ b/packages/icons-svg/package.json
@@ -27,6 +27,7 @@
     "build:es": "tsc --project tsconfig.build.json --module esnext --outDir es",
     "build:lib": "tsc --project tsconfig.build.json --module commonjs --outDir lib",
     "build": "cross-env NODE_ENV=production ut build:es && cross-env NODE_ENV=production ut build:lib",
+    "prepare": "npm run generate && npm run build",
     "test": "cross-env NODE_ENV=test vitest run",
     "test:unit": "vitest run",
     "prepublishOnly": "ut test && ut g && ut build && ut type-check && ut digest",


### PR DESCRIPTION
## Summary

After a clean install (`npm install`, `pnpm install`, etc.), `packages/icons-svg/lib` is empty, and any downstream consumer that imports from `@ant-design/icons-svg` fails. The build step was only declared in `prepublishOnly`, which only runs on `npm publish`. Adding `prepare` makes the build run on install, which is npm's standard convention for workspace source packages that ship a build artifact.

## Reproduce on `master` (no fix)

```bash
git clean -dfx
npm install
cd packages/icons-react
npm run prepublishOnly   # ← FAILS
```

Failure output:

```
> @ant-design/icons@6.2.2 generate
> rimraf src/icons && TS_NODE_PROJECT=scripts/tsconfig.json node -r ts-node/register scripts/generate.ts

TSError: ⨯ Unable to compile TypeScript:
scripts/generate.ts(1,30): error TS2307: Cannot find module '@ant-design/icons-svg' or its corresponding type declarations.
scripts/generate.ts(2,32): error TS2307: Cannot find module '@ant-design/icons-svg/es/types' or its corresponding type declarations.
```

This happens because `packages/icons-svg`'s `main` is `lib/index.js`, but `lib/` is only produced by the `build` step, which is only invoked from `prepublishOnly`. From a fresh checkout there is no `lib/`, so the workspace symlink points to a package that cannot resolve.

## Fix

Single line in `packages/icons-svg/package.json`:

```diff
+ "prepare": "npm run generate && npm run build",
```

`prepare` is the standard npm lifecycle hook for "run before a package is consumed" — it runs on `npm install`, on git/file dependencies, and on `npm publish`. Using `npm run …` (rather than calling a specific package manager directly) keeps it package-manager-agnostic.

## Test plan

- [x] `git clean -dfx && npm install` → `packages/icons-svg/lib/asn/*` is generated automatically
- [x] `cd packages/icons-react && npm run prepublishOnly` → passes end-to-end: generate → father build (840 files) → lint → vitest (4 files / 40 tests)
- [x] No change to the published artifact: `prepublishOnly` still does the full `test && generate && build && type-check && digest` flow before publishing.
