### PR TITLE
fix: make ESM wrapper interop-agnostic for Turbopack SSR

### DIFF
--- a/packages/icons-react/index.mjs
+++ b/packages/icons-react/index.mjs
@@ -1,3 +1,3 @@
 import _mod from './lib/index.js';
-export default _mod.default;
+export default _mod.default ?? _mod;
 export * from './lib/index.js';


### PR DESCRIPTION
Fixes #729

## Summary

`import Icon from '@ant-design/icons'` resolves to `undefined` under Turbopack SSR in 6.2.3, breaking every consumer of the customizable `Icon` component (including custom icons and antd-internal call sites). Named imports are unaffected. This is a regression from #719.

## Root cause

The `node.import` wrapper added in #719 (`packages/icons-react/index.mjs`) reads:

```js
import _mod from './lib/index.js';
export default _mod.default;
export * from './lib/index.js';
```

`lib/index.js` is the CJS build with `__esModule: true` and `exports.default = Icon`. What `_mod` binds to depends on the host's CJS interop:

- **Node-native ESM** (#718, #726): `_mod` is `module.exports`, so `_mod.default` is the `Icon` component. ✅
- **Turbopack** (#729): honors `__esModule` and binds `_mod` directly to `exports.default` (already the `Icon`). `_mod.default` is then `Icon.default` → `undefined`. ❌

PR #719 only matched the `node.import` condition, but Turbopack also matches it during SSR, so its CJS interop runs against the wrapper too.

## Fix

```diff
 import _mod from './lib/index.js';
-export default _mod.default;
+export default _mod.default ?? _mod;
 export * from './lib/index.js';
```

`_mod.default ?? _mod` handles both interop flavors:

- Node-native: `_mod.default` is the `Icon` forwardRef object (truthy) → used as-is.
- Turbopack: `_mod` *is* `Icon`, so `_mod.default` is `undefined` → fall back to `_mod`.

`lib/index.js` always defines `exports.default` explicitly, so there's no realistic case where `_mod` lacks `.default` while not being the component itself. `export *` was already correct for both bundlers (named imports were never broken in #729), so it's untouched.

## Verification

I reproduced #729 following the provided instructions. I then confirmed the icon renders successfully with this patch applied to the installed wrapper.

I also re-verified the original #718 / #726 fixes still hold:
- React Router 7 + Vite SSR (repro from #718): renders.
- Vite official React SSR example + built-in icon (repro from #726): renders, no `ERR_MODULE_NOT_FOUND`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了包的默认导出处理机制，确保在主导出不可用时能正确回退，提高模块导出的可靠性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-icons/pull/730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->