### PR TITLE
fix(icons-react): avoid deep @rc-component/util imports

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@ant-design/colors": "^8.0.1",
     "@ant-design/icons-svg": "^4.4.2",
-    "@rc-component/util": "^1.10.1",
+    "@rc-component/util": "^1.11.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/icons-react/src/components/Icon.tsx
+++ b/packages/icons-react/src/components/Icon.tsx
@@ -1,7 +1,7 @@
 // Seems this is used for iconFont
 import * as React from 'react';
 import { clsx } from 'clsx';
-import { useComposeRef } from '@rc-component/util/lib/ref';
+import { useComposeRef } from '@rc-component/util';
 import Context from './Context';
 
 import { svgBaseProps, warning, useInsertStyles } from '../utils';

--- a/packages/icons-react/src/utils.ts
+++ b/packages/icons-react/src/utils.ts
@@ -1,8 +1,6 @@
 import { generate as generateColor } from '@ant-design/colors';
 import type { AbstractNode, IconDefinition } from '@ant-design/icons-svg/lib/types';
-import { updateCSS } from '@rc-component/util/lib/Dom/dynamicCSS';
-import { getShadowRoot } from '@rc-component/util/lib/Dom/shadow';
-import { warningOnce } from '@rc-component/util/lib/warning';
+import { updateCSS, getShadowRoot, warning as warningOnce } from '@rc-component/util';
 import type { CSSProperties, MouseEventHandler, MutableRefObject, ReactNode } from 'react';
 import React, { useContext, useEffect } from 'react';
 import IconContext from './components/Context';


### PR DESCRIPTION
When I opened #730, I noticed `react:ci`  is failing due to

```
/home/runner/work/ant-design-icons/ant-design-icons/packages/icons-react/src/components/Icon.tsx
Error:   4:1  error  '@rc-component/util/lib/ref' import is restricted from being used by a pattern. Do not import package internals from es/lib. Import from the package root  no-restricted-imports

/home/runner/work/ant-design-icons/ant-design-icons/packages/icons-react/src/utils.ts
Error:   3:1  error  '@rc-component/util/lib/Dom/dynamicCSS' import is restricted from being used by a pattern. Do not import package internals from es/lib. Import from the package root  no-restricted-imports
Error:   4:1  error  '@rc-component/util/lib/Dom/shadow' import is restricted from being used by a pattern. Do not import package internals from es/lib. Import from the package root      no-restricted-imports
Error:   5:1  error  '@rc-component/util/lib/warning' import is restricted from being used by a pattern. Do not import package internals from es/lib. Import from the package root         no-restricted-imports
```

I think it's related to https://github.com/react-component/father-plugin/pull/18.

This PR updates the imports accordingly. I also had to bump `@rc-component/util` to `^1.11.0` as that's when some of the named exports were made available from the root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 升级了 `@rc-component/util` 依赖版本至 1.11.0
  * 调整了图标库中相关模块的导入方式，以确保与最新依赖版本兼容并优化代码结构

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-icons/pull/731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->