### PR TITLE
fix: pass iconfont color to svg

### DIFF
--- a/packages/icons-react/src/components/Icon.tsx
+++ b/packages/icons-react/src/components/Icon.tsx
@@ -17,6 +17,7 @@ export interface CustomIconComponentProps {
   fill?: string;
   viewBox?: string;
   className?: string;
+  color?: string;
   style?: React.CSSProperties;
 }
 export interface IconComponentProps extends IconBaseProps {
@@ -37,6 +38,7 @@ const Icon: React.ForwardRefExoticComponent<
     // affect inner <svg>...</svg>
     component: Component,
     viewBox,
+    color,
     spin,
     rotate,
 
@@ -79,6 +81,7 @@ const Icon: React.ForwardRefExoticComponent<
   const innerSvgProps: CustomIconComponentProps = {
     ...svgBaseProps,
     className: svgClassString,
+    color,
     style: svgStyle,
     viewBox,
   };

--- a/packages/icons-react/tests/index.test.tsx
+++ b/packages/icons-react/tests/index.test.tsx
@@ -358,6 +358,12 @@ describe('Icon.createFromIconfontCN()', () => {
     expect(snapshotOf(wrapper)).toMatchSnapshot();
   });
 
+  it('should apply color prop to svg', () => {
+    const { container } = testingLibRender(<IconFont type="icon-twitter" color="blue" />);
+
+    expect(container.querySelector('svg')?.getAttribute('color')).toBe('blue');
+  });
+
   it('should support event listeners', () => {
     const onClickHandler = jest.fn();
     const onKeyUpHandler = jest.fn();


### PR DESCRIPTION
## What

- Pass `color` from custom `Icon` props into the inner SVG props.
- Add a regression test for `createFromIconfontCN()` so `IconFont color="..."` applies to the rendered `<svg>`.

## Why

This takes over the still-valid behavior fix from #498 / #497 on a clean branch based on the current `master`.

## Testing

- `npm test --workspace @ant-design/icons -- --run tests/index.test.tsx`
- `ut react:ci`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 图标组件现在支持直接传入 `color`，并会应用到图标本身的渲染效果。
* **测试**
  * 补充了相关验证，确保使用图标字体方案时，`color` 属性会正确生效。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->