### PR TITLE
fix: type-check icons svg inline generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       #   run: |
       #     echo "ut install failed — failing job after uploading logs"
       #     exit 1
+      - run: ut icons:type-check
       - run: ut icons:generate && ut icons:build
       - run: ut icons:test
       - id: ut_ci

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "rn:generate": "ut generate --workspace @ant-design/icons-react-native",
     "icons:generate": "ut generate --workspace @ant-design/icons-svg",
     "icons:build": "ut build --workspace @ant-design/icons-svg",
+    "icons:type-check": "ut type-check --workspace @ant-design/icons-svg",
     "icons:test": "ut test --workspace @ant-design/icons-svg",
     "react:ci": "ut ci --workspace @ant-design/icons",
     "angular:ci": "ut ci --workspace @ant-design/icons-angular-workspace",

--- a/packages/icons-svg/tasks/creators/generateInline.ts
+++ b/packages/icons-svg/tasks/creators/generateInline.ts
@@ -1,13 +1,15 @@
 import { src, dest } from 'gulp';
-import * as File from 'vinyl';
+import File from 'vinyl';
 import { useRender } from '../../plugins';
 import type { RenderCustomData } from '../../plugins/render';
 import type { IconDefinition } from '../../templates/types';
 import type { HelperRenderOptions } from '../../templates/helpers';
 
+type RenderedFile = File & { _meta?: RenderCustomData };
+
 export interface GenerateInlineOptions {
   from: string[];
-  toDir: (file: File & { _renderData?: RenderCustomData }) => string;
+  toDir: (file: RenderedFile) => string;
   getIconDefinitionFromSource: (raw: string) => IconDefinition;
   renderOptions?: HelperRenderOptions;
 }


### PR DESCRIPTION
## Summary

- Fix the `icons-svg` inline generation task type so `tsc --noEmit` accepts the Gulp `dest` callback.
- Add an `icons:type-check` root script and run it in GitHub CI before generating/building icons.

## Test Plan

- `ut icons:type-check && ut icons:generate && ut icons:build && ut icons:test`
