### PR TITLE
chore: update @ant-design/icons to 6.3.1

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/icons",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "repository": "https://github.com/ant-design/ant-design-icons/tree/master/packages/icons-react",
   "license": "MIT",
   "contributors": [
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@ant-design/colors": "^8.0.1",
-    "@ant-design/icons-svg": "^4.4.2",
+    "@ant-design/icons-svg": "^4.5.0",
     "@rc-component/util": "^1.11.0",
     "clsx": "^2.1.1"
   },


### PR DESCRIPTION
## Summary

- update `@ant-design/icons` to `6.3.1`
- update the React package dependency on `@ant-design/icons-svg` to `^4.5.0`

## Related Issues

- Related to https://github.com/ant-design/ant-design-icons/issues/744
- Related to https://github.com/ant-design/ant-design-icons/issues/745

## Test Plan

- Not run, per maintainer request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新了图标相关包的版本，并同步提升了运行时依赖版本。
  * 这次变更为后续使用提供了更稳定的版本基础。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->