### PR TITLE
fix(react): keep ESM icon imports native

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -71,7 +71,7 @@
   "scripts": {
     "ci": "NODE_ENV=ci npm run prepublishOnly",
     "clean": "./scripts/cleanup.sh",
-    "compile": "father build",
+    "compile": "father build && node scripts/rewrite-esm-imports.cjs",
     "generate": "rimraf src/icons && TS_NODE_PROJECT=scripts/tsconfig.json node -r ts-node/register scripts/generate.ts",
     "lint": "eslint src/ --ext .tsx,.ts",
     "prepublishOnly": "npm run generate && npm run compile && npm run lint && npm run test",

--- a/packages/icons-react/scripts/rewrite-esm-imports.cjs
+++ b/packages/icons-react/scripts/rewrite-esm-imports.cjs
@@ -1,0 +1,47 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const cjsIconPrefix = '@ant-design/icons-svg/lib/asn/';
+const esmIconPrefix = '@ant-design/icons-svg/es/asn/';
+
+function rewriteEsmIconImports(iconsDir) {
+  const files = fs.readdirSync(iconsDir).filter((file) => file.endsWith('.js'));
+  let iconImports = 0;
+  let rewrittenFiles = 0;
+  let rewrittenImports = 0;
+
+  files.forEach((file) => {
+    const filePath = path.join(iconsDir, file);
+    const source = fs.readFileSync(filePath, 'utf8');
+    const cjsMatches = source.split(cjsIconPrefix).length - 1;
+    const esmMatches = source.split(esmIconPrefix).length - 1;
+
+    iconImports += cjsMatches + esmMatches;
+
+    if (cjsMatches === 0) {
+      return;
+    }
+
+    fs.writeFileSync(filePath, source.split(cjsIconPrefix).join(esmIconPrefix));
+    rewrittenFiles += 1;
+    rewrittenImports += cjsMatches;
+  });
+
+  if (iconImports === 0) {
+    throw new Error(`No generated icon imports found in ${iconsDir}`);
+  }
+
+  return { files: files.length, iconImports, rewrittenFiles, rewrittenImports };
+}
+
+if (require.main === module) {
+  const iconsDir = path.resolve(__dirname, '../es/icons');
+  const result = rewriteEsmIconImports(iconsDir);
+  console.log(
+    `Checked ${result.iconImports} ESM icon imports; rewrote ${result.rewrittenImports} in ${result.rewrittenFiles} files.`,
+  );
+}
+
+module.exports = { rewriteEsmIconImports };

--- a/packages/icons-react/tests/rewriteEsmImports.test.ts
+++ b/packages/icons-react/tests/rewriteEsmImports.test.ts
@@ -1,0 +1,65 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const { rewriteEsmIconImports } = require('../scripts/rewrite-esm-imports.cjs');
+
+describe('rewriteEsmIconImports', () => {
+  let iconsDir: string;
+
+  beforeEach(() => {
+    iconsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'icons-react-esm-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(iconsDir, { recursive: true, force: true });
+  });
+
+  it('rewrites only generated ESM icon imports', () => {
+    const iconPath = path.join(iconsDir, 'SmileOutlined.js');
+    const unrelatedPath = path.join(iconsDir, 'index.js');
+
+    fs.writeFileSync(
+      iconPath,
+      "import icon from '@ant-design/icons-svg/lib/asn/SmileOutlined';\nexport default icon;\n",
+    );
+    fs.writeFileSync(unrelatedPath, "export { default } from './SmileOutlined';\n");
+
+    expect(rewriteEsmIconImports(iconsDir)).toEqual({
+      files: 2,
+      iconImports: 1,
+      rewrittenFiles: 1,
+      rewrittenImports: 1,
+    });
+    expect(fs.readFileSync(iconPath, 'utf8')).toContain(
+      '@ant-design/icons-svg/es/asn/SmileOutlined',
+    );
+    expect(fs.readFileSync(unrelatedPath, 'utf8')).toBe(
+      "export { default } from './SmileOutlined';\n",
+    );
+  });
+
+  it('is idempotent after the first rewrite', () => {
+    const iconPath = path.join(iconsDir, 'SmileOutlined.js');
+
+    fs.writeFileSync(
+      iconPath,
+      "import icon from '@ant-design/icons-svg/lib/asn/SmileOutlined';\nexport default icon;\n",
+    );
+
+    rewriteEsmIconImports(iconsDir);
+
+    expect(rewriteEsmIconImports(iconsDir)).toEqual({
+      files: 1,
+      iconImports: 1,
+      rewrittenFiles: 0,
+      rewrittenImports: 0,
+    });
+  });
+
+  it('fails when the expected generated imports are absent', () => {
+    fs.writeFileSync(path.join(iconsDir, 'index.js'), 'export const icons = {};\n');
+
+    expect(() => rewriteEsmIconImports(iconsDir)).toThrow('No generated icon imports found');
+  });
+});


### PR DESCRIPTION
## Summary

- rewrite generated React ESM icon imports from `@ant-design/icons-svg/lib/asn/*` to the matching `es/asn/*` entry after `father build`
- keep source and CommonJS output on `lib/asn/*`, so the CJS build does not start depending on ESM files
- add focused coverage for rewrite scope, idempotency, and a missing-output guard

Fixes #760.

## Why this is build-specific

The generated TypeScript source feeds both the ESM and CommonJS builds. Changing the generator itself to import `es/asn/*` would also make `lib/icons/*` require the ESM SVG build. The post-build rewrite changes only `packages/icons-react/es/icons/*.js` and leaves all 848 CommonJS icon imports unchanged.

## Verification

Exact base: `6c18c63fbcfcf71dae09cd6bd6d63a48f8b688f1`

- Bun 1.4.0 baseline bundle reproduced the warning `icon should be icon definiton, but got [object Object]`; server rendering returned `<span role="img" class="anticon"></span>` with no SVG
- fixed Bun bundle renders the SVG successfully
- Node CommonJS server-render smoke also renders the SVG
- clean `NODE_ENV=ci` React compile passed and rewrote 848/848 ESM icon imports
- a second rewrite passed with 0 changes, confirming idempotency
- Vitest: 5/5 files, 49/49 tests
- source ESLint passed
- bundle-size smoke passed for all five ESM/CJS cases
- Prettier and `git diff --check` passed

I checked current open PR titles, bodies, and changed files. No open PR addresses #760 or this ESM/CJS import split; #754 also edits `packages/icons-react/package.json` for a dumi dependency bump but does not overlap this script or behavior.

AI assistance disclosure: Codex was used to trace the dual-output build, reproduce the exact-base Bun failure, implement the post-build rewrite and tests, audit open PR overlap, and run verification. I reviewed the diff and results before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化图标构建流程，自动将生成文件中的图标导入调整为 ESM 格式。
  * 提升构建产物的模块兼容性与加载效率。

* **测试**
  * 增加导入重写、重复执行及异常场景的验证，确保处理结果稳定可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->