### PR TITLE
fix(react): guard invalid icon definitions

### DIFF
--- a/packages/icons-react/src/components/AntdIcon.tsx
+++ b/packages/icons-react/src/components/AntdIcon.tsx
@@ -53,7 +53,7 @@ const Icon = React.forwardRef<HTMLSpanElement, IconComponentProps>((props, ref) 
 
   const { prefixCls = 'anticon', rootClassName } = React.useContext(Context);
 
-  warning(isIconDefinition(icon), `icon should be icon definiton, but got ${icon}`);
+  warning(isIconDefinition(icon), `icon should be icon definiton, but got ${typeof icon}`);
 
   if (!isIconDefinition(icon)) {
     return null;

--- a/packages/icons-react/src/components/AntdIcon.tsx
+++ b/packages/icons-react/src/components/AntdIcon.tsx
@@ -10,6 +10,7 @@ import ReactIcon from './IconBaseTwoTone';
 import { getTwoToneColor, setTwoToneColor } from './twoTonePrimaryColor';
 import type { TwoToneColor } from './twoTonePrimaryColor';
 import { DEFAULT_TWOTONE_COLOR } from '../colorUtils';
+import { isIconDefinition, warning } from '../renderUtils';
 import { normalizeTwoToneColors } from '../utils';
 
 export interface AntdIconProps extends IconBaseProps {
@@ -51,6 +52,12 @@ const Icon = React.forwardRef<HTMLSpanElement, IconComponentProps>((props, ref) 
   } = props;
 
   const { prefixCls = 'anticon', rootClassName } = React.useContext(Context);
+
+  warning(isIconDefinition(icon), `icon should be icon definiton, but got ${icon}`);
+
+  if (!isIconDefinition(icon)) {
+    return null;
+  }
 
   const classString = clsx(
     rootClassName,

--- a/packages/icons-react/src/components/AntdIconLight.tsx
+++ b/packages/icons-react/src/components/AntdIconLight.tsx
@@ -8,6 +8,7 @@ import Context from './Context';
 import type { IconBaseProps } from './Icon';
 import ReactIcon from './IconBase';
 import type { TwoToneColor } from './twoTonePrimaryColor';
+import { isIconDefinition, warning } from '../renderUtils';
 
 export interface AntdIconProps extends IconBaseProps {
   twoToneColor?: TwoToneColor;
@@ -37,6 +38,12 @@ const Icon = React.forwardRef<HTMLSpanElement, IconComponentProps>((props, ref) 
   } = props;
 
   const { prefixCls = 'anticon', rootClassName } = React.useContext(Context);
+
+  warning(isIconDefinition(icon), `icon should be icon definiton, but got ${icon}`);
+
+  if (!isIconDefinition(icon)) {
+    return null;
+  }
 
   const classString = clsx(
     rootClassName,

--- a/packages/icons-react/src/components/AntdIconLight.tsx
+++ b/packages/icons-react/src/components/AntdIconLight.tsx
@@ -39,7 +39,7 @@ const Icon = React.forwardRef<HTMLSpanElement, IconComponentProps>((props, ref) 
 
   const { prefixCls = 'anticon', rootClassName } = React.useContext(Context);
 
-  warning(isIconDefinition(icon), `icon should be icon definiton, but got ${icon}`);
+  warning(isIconDefinition(icon), `icon should be icon definiton, but got ${typeof icon}`);
 
   if (!isIconDefinition(icon)) {
     return null;

--- a/packages/icons-react/src/components/IconBase.tsx
+++ b/packages/icons-react/src/components/IconBase.tsx
@@ -27,7 +27,7 @@ const IconBase: React.FC<IconProps> = props => {
 
   useInsertStyles(svgRef);
 
-  warning(isIconDefinition(icon), `icon should be icon definiton, but got ${icon}`);
+  warning(isIconDefinition(icon), `icon should be icon definiton, but got ${typeof icon}`);
 
   if (!isIconDefinition(icon)) {
     return null;

--- a/packages/icons-react/src/components/IconBaseTwoTone.tsx
+++ b/packages/icons-react/src/components/IconBaseTwoTone.tsx
@@ -51,7 +51,7 @@ const IconBaseTwoTone: IconBaseTwoToneComponent<IconProps> = props => {
 
   useInsertStyles(svgRef);
 
-  warning(isIconDefinition(icon), `icon should be icon definiton, but got ${icon}`);
+  warning(isIconDefinition(icon), `icon should be icon definiton, but got ${typeof icon}`);
 
   if (!isIconDefinition(icon)) {
     return null;

--- a/packages/icons-react/src/renderUtils.ts
+++ b/packages/icons-react/src/renderUtils.ts
@@ -14,6 +14,7 @@ export function warning(valid: boolean, message: string) {
 
 export function isIconDefinition(target: any): target is IconDefinition {
   return (
+    target !== null &&
     typeof target === 'object' &&
     typeof target.name === 'string' &&
     typeof target.theme === 'string' &&

--- a/packages/icons-react/tests/index.test.tsx
+++ b/packages/icons-react/tests/index.test.tsx
@@ -90,10 +90,14 @@ describe('Icon', () => {
   mountTest(CheckCircleTwoTone);
 
   it.each([
-    ['single-tone', AntdIconLight],
-    ['two-tone', AntdIcon],
-  ])('should render null for an invalid %s icon definition', (_, IconComponent) => {
-    const { container } = testingLibRender(<IconComponent icon={undefined as any} />);
+    ['undefined single-tone', AntdIconLight, undefined],
+    ['null single-tone', AntdIconLight, null],
+    ['symbol single-tone', AntdIconLight, Symbol('icon')],
+    ['undefined two-tone', AntdIcon, undefined],
+    ['null two-tone', AntdIcon, null],
+    ['symbol two-tone', AntdIcon, Symbol('icon')],
+  ])('should render null for an invalid %s icon definition', (_, IconComponent, icon) => {
+    const { container } = testingLibRender(<IconComponent icon={icon as any} />);
 
     expect(container.innerHTML).toBe('');
   });

--- a/packages/icons-react/tests/index.test.tsx
+++ b/packages/icons-react/tests/index.test.tsx
@@ -16,6 +16,8 @@ import Icon, {
   SyncOutlined,
 } from '../src';
 import { getSecondaryColor } from '../src/utils';
+import AntdIcon from '../src/components/AntdIcon';
+import AntdIconLight from '../src/components/AntdIconLight';
 
 const simulate = (node: Element, event: string) => {
   switch (event) {
@@ -86,6 +88,15 @@ function mountTest(Component) {
 describe('Icon', () => {
   mountTest(HomeOutlined);
   mountTest(CheckCircleTwoTone);
+
+  it.each([
+    ['single-tone', AntdIconLight],
+    ['two-tone', AntdIcon],
+  ])('should render null for an invalid %s icon definition', (_, IconComponent) => {
+    const { container } = testingLibRender(<IconComponent icon={undefined as any} />);
+
+    expect(container.innerHTML).toBe('');
+  });
 
   it('should render to a <span class="xxx"><svg>...</svg></span>', () => {
     const wrapper = render(<HomeOutlined className="my-icon-classname" />);


### PR DESCRIPTION
### Summary

- validate icon definitions before the outer icon wrappers read `icon.name`
- apply the existing warning-and-null behavior to both single-tone and two-tone wrappers
- make the shared validator and warning path safe for undefined, null, and Symbol inputs
- add regressions for all three invalid values in both render paths

The inner SVG renderers already reject invalid definitions, but the outer wrappers dereference `icon.name` first. That makes the existing guard unreachable for an undefined definition and crashes the React tree. This moves the same validation boundary ahead of those accesses while preserving the development warning.

This prevents the crash reported in #759. It does not claim to identify the reporter's production-only module-resolution cause; an unresolved definition renders nothing and emits the existing development warning instead of throwing.

Fixes #759.

### Validation

- baseline regressions: undefined fails at `icon.name`; null fails inside `isIconDefinition`; Symbol fails while formatting the warning
- `npm test --workspace @ant-design/icons` (52/52)
- `npm run lint --workspace @ant-design/icons`
- `npm run compile --workspace @ant-design/icons`
- `git diff --check`

The React Native CI job also fails on the exact base revision (`6c18c63f`) with an unrelated React type mismatch while generating declarations; React, Vue, and Angular jobs pass.

AI assistance disclosure: Codex was used to trace the render paths, audit open PR overlap, implement the guard, process review feedback, and run validation. Each failure was reproduced before its corresponding fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 增强图标组件的参数校验，传入无效图标定义时会发出警告。
  * 无效图标不再继续渲染，避免显示异常或运行时错误。
  * 警告信息现在显示无效参数的类型，提升问题排查体验。
  * 补充双色和单色图标组件对无效参数的处理验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->