### PR TITLE
fix(react): isolate custom prefix styles

### DIFF
--- a/packages/icons-react/src/renderUtils.ts
+++ b/packages/icons-react/src/renderUtils.ts
@@ -158,7 +158,7 @@ export const useInsertStyles = (eleRef: React.RefObject<HTMLElement>) => {
     const ele = eleRef.current;
     const shadowRoot = getShadowRoot(ele);
 
-    updateCSS(mergedStyleStr, '@ant-design-icons', {
+    updateCSS(mergedStyleStr, prefixCls ? `@ant-design-icons-${prefixCls}` : '@ant-design-icons', {
       prepend: !layer,
       csp,
       attachTo: shadowRoot,

--- a/packages/icons-react/tests/iconStyles.test.tsx
+++ b/packages/icons-react/tests/iconStyles.test.tsx
@@ -41,6 +41,25 @@ describe('Render with styles', () => {
     expect(shadow.querySelector('style')).toBeTruthy();
   });
 
+  it('isolates styles for multiple custom prefixes', () => {
+    render(
+      <>
+        <IconProvider value={{ prefixCls: 'plugin-a-icon' }}>
+          <Icon icon={TwitterOutlined} />
+        </IconProvider>
+        <IconProvider value={{ prefixCls: 'plugin-b-icon' }}>
+          <Icon icon={TwitterOutlined} />
+        </IconProvider>
+      </>,
+    );
+
+    const styles = Array.from(document.head.querySelectorAll('style'));
+
+    expect(styles).toHaveLength(2);
+    expect(styles.some((style) => style.textContent?.includes('.plugin-a-icon {'))).toBe(true);
+    expect(styles.some((style) => style.textContent?.includes('.plugin-b-icon {'))).toBe(true);
+  });
+
   it('updateCSS should do nothing without DOM', () => {
     vi.stubGlobal('window', undefined);
 


### PR DESCRIPTION
### Summary

- include a custom `IconProvider.prefixCls` in the injected stylesheet cache key
- preserve the existing `@ant-design-icons` key for the default prefix
- verify that two providers with different custom prefixes retain both style sheets

`useInsertStyles` already generates different CSS for each custom prefix, but every provider passed the same `@ant-design-icons` key to `updateCSS`. Mounting a second provider therefore replaced the first provider's stylesheet. Custom prefixes now receive distinct keys while the default path remains unchanged.

Fixes #650.

### Validation

- baseline regression: two custom-prefix providers produce only one style node on `master`
- `npm test --workspace @ant-design/icons` (47/47)
- `npm run lint --workspace @ant-design/icons`
- `npm run compile --workspace @ant-design/icons`
- Prettier check for both changed files
- `git diff --check`

AI assistance disclosure: Codex was used to trace the stylesheet cache path, audit open PR overlap, implement the fix, and run validation. I reproduced the overwrite against the exact base revision before applying the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复使用多个自定义图标前缀时的样式隔离问题，避免不同前缀之间相互覆盖。

* **测试**
  * 增加多前缀场景验证，确保每个自定义前缀生成独立且匹配的样式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->