### PR TITLE
fix(vue): guard unavailable ShadowRoot

### DIFF
--- a/packages/icons-vue/src/utils.ts
+++ b/packages/icons-vue/src/utils.ts
@@ -165,7 +165,7 @@ function inShadow(ele: Node) {
   if (!canUseDom()) {
     return false;
   }
-  return getRoot(ele) instanceof ShadowRoot;
+  return typeof ShadowRoot !== 'undefined' && getRoot(ele) instanceof ShadowRoot;
 }
 
 /**

--- a/packages/icons-vue/test/index.test.tsx
+++ b/packages/icons-vue/test/index.test.tsx
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import Icon, {
   getTwoToneColor,
   setTwoToneColor,
@@ -12,6 +13,17 @@ import Icon, {
   ClockCircleOutlined,
 } from '../src';
 describe('Icon', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should render when ShadowRoot is unavailable', async () => {
+    vi.stubGlobal('ShadowRoot', undefined);
+
+    expect(() => mount(HomeOutlined)).not.toThrow();
+    await nextTick();
+  });
+
   it('should render to a <span class="xxx"><svg>...</svg></span>', () => {
     const wrapper = mount(HomeOutlined, { props: { class: 'my-icon-class' } });
     expect(wrapper.html()).toMatchSnapshot();


### PR DESCRIPTION
## Summary

- guard the Vue shadow-root check when the global `ShadowRoot` constructor is unavailable
- add a regression test for DOM-like runtimes that do not expose `ShadowRoot`

Fixes #597.

## Root cause

`inShadow` first checked `canUseDom()`, but then always evaluated `getRoot(ele) instanceof ShadowRoot`. Some Nuxt/SSR-compatible or partial DOM runtimes expose `window` and `document` without a global `ShadowRoot`, so the right-hand side of `instanceof` is invalid.

The React package already uses the same `typeof ShadowRoot !== "undefined"` guard in its shadow-root helper.

## Verification

On exact base `6c18c63fbcfcf71dae09cd6bd6d63a48f8b688f1`, the regression test produced an unhandled rejection:

- `TypeError: Right-hand side of instanceof is not an object`
- `packages/icons-vue/src/utils.ts:168`

After the fix:

- Vue Vitest suite: 14 passed
- Vue ESLint: passed
- Vue compile: ESM, CJS, and declarations passed
- Prettier check for changed files: passed
- `git diff --check`: passed

AI assistance disclosure: Codex was used to trace the current source, audit open PR overlap, add the regression test, and run validation. The failure and fix were verified locally against the exact current base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复在不支持 Shadow DOM 的环境中渲染图标时可能出现的错误。
  * 提升了图标组件在兼容性受限环境下的稳定性。

* **测试**
  * 新增无 Shadow DOM 环境下的渲染测试，确保图标能够正常加载。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->