### PR TITLE
fix: continue past cached iconfont scripts

### DIFF
--- a/packages/icons-react/src/components/IconFont.tsx
+++ b/packages/icons-react/src/components/IconFont.tsx
@@ -14,34 +14,35 @@ export interface IconFontProps<T extends string = string> extends IconBaseProps 
 }
 
 function isValidCustomScriptUrl(scriptUrl: string): boolean {
-  return Boolean(
-    typeof scriptUrl === 'string'
-      && scriptUrl.length
-      && !customCache.has(scriptUrl)
-  );
+  return Boolean(typeof scriptUrl === 'string' && scriptUrl.length && !customCache.has(scriptUrl));
 }
 
 function createScriptUrlElements(scriptUrls: string[], index: number = 0): void {
   const currentScriptUrl = scriptUrls[index];
-  if (isValidCustomScriptUrl(currentScriptUrl)) {
-    const script = document.createElement('script');
-    script.setAttribute('src', currentScriptUrl);
-    script.setAttribute('data-namespace', currentScriptUrl);
+  if (!isValidCustomScriptUrl(currentScriptUrl)) {
     if (scriptUrls.length > index + 1) {
-      script.onload = () => {
-        createScriptUrlElements(scriptUrls, index + 1);
-      };
-      script.onerror = () => {
-        createScriptUrlElements(scriptUrls, index + 1);
-      };
+      createScriptUrlElements(scriptUrls, index + 1);
     }
-    customCache.add(currentScriptUrl);
-    document.body.appendChild(script);
+    return;
   }
+
+  const script = document.createElement('script');
+  script.setAttribute('src', currentScriptUrl);
+  script.setAttribute('data-namespace', currentScriptUrl);
+  if (scriptUrls.length > index + 1) {
+    script.onload = () => {
+      createScriptUrlElements(scriptUrls, index + 1);
+    };
+    script.onerror = () => {
+      createScriptUrlElements(scriptUrls, index + 1);
+    };
+  }
+  customCache.add(currentScriptUrl);
+  document.body.appendChild(script);
 }
 
 export default function create<T extends string = string>(
-  options: CustomIconOptions = {}
+  options: CustomIconOptions = {},
 ): React.FC<IconFontProps<T>> {
   const { scriptUrl, extraCommonProps = {} } = options;
 

--- a/packages/icons-react/tests/iconFont.test.tsx
+++ b/packages/icons-react/tests/iconFont.test.tsx
@@ -1,0 +1,23 @@
+import createFromIconfontCN from '../src/components/IconFont';
+
+describe('createFromIconfontCN script loading', () => {
+  afterEach(() => {
+    document
+      .querySelectorAll('script[data-namespace^="/iconfont-cache-test-react-"]')
+      .forEach((script) => script.remove());
+  });
+
+  it('continues loading after a cached script URL', () => {
+    const cachedUrl = '/iconfont-cache-test-react-cached.js';
+    const freshUrl = '/iconfont-cache-test-react-fresh.js';
+
+    createFromIconfontCN({ scriptUrl: cachedUrl });
+    createFromIconfontCN({ scriptUrl: [freshUrl, cachedUrl] });
+
+    expect(
+      [...document.querySelectorAll('script')].some(
+        (script) => script.dataset.namespace === freshUrl,
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/icons-vue/src/components/IconFont.tsx
+++ b/packages/icons-vue/src/components/IconFont.tsx
@@ -22,21 +22,26 @@ function isValidCustomScriptUrl(scriptUrl: string): boolean {
 
 function createScriptUrlElements(scriptUrls: string[], index: number = 0): void {
   const currentScriptUrl = scriptUrls[index];
-  if (isValidCustomScriptUrl(currentScriptUrl)) {
-    const script = document.createElement('script');
-    script.setAttribute('src', currentScriptUrl);
-    script.setAttribute('data-namespace', currentScriptUrl);
+  if (!isValidCustomScriptUrl(currentScriptUrl)) {
     if (scriptUrls.length > index + 1) {
-      script.onload = () => {
-        createScriptUrlElements(scriptUrls, index + 1);
-      };
-      script.onerror = () => {
-        createScriptUrlElements(scriptUrls, index + 1);
-      };
+      createScriptUrlElements(scriptUrls, index + 1);
     }
-    customCache.add(currentScriptUrl);
-    document.body.appendChild(script);
+    return;
   }
+
+  const script = document.createElement('script');
+  script.setAttribute('src', currentScriptUrl);
+  script.setAttribute('data-namespace', currentScriptUrl);
+  if (scriptUrls.length > index + 1) {
+    script.onload = () => {
+      createScriptUrlElements(scriptUrls, index + 1);
+    };
+    script.onerror = () => {
+      createScriptUrlElements(scriptUrls, index + 1);
+    };
+  }
+  customCache.add(currentScriptUrl);
+  document.body.appendChild(script);
 }
 
 export default function create(

--- a/packages/icons-vue/test/iconFont.test.tsx
+++ b/packages/icons-vue/test/iconFont.test.tsx
@@ -1,0 +1,23 @@
+import createFromIconfontCN from '../src/components/IconFont';
+
+describe('createFromIconfontCN script loading', () => {
+  afterEach(() => {
+    document
+      .querySelectorAll('script[data-namespace^="/iconfont-cache-test-vue-"]')
+      .forEach(script => script.remove());
+  });
+
+  it('continues loading after a cached script URL', () => {
+    const cachedUrl = '/iconfont-cache-test-vue-cached.js';
+    const freshUrl = '/iconfont-cache-test-vue-fresh.js';
+
+    createFromIconfontCN({ scriptUrl: cachedUrl });
+    createFromIconfontCN({ scriptUrl: [freshUrl, cachedUrl] });
+
+    expect(
+      [...document.querySelectorAll('script')].some(
+        script => script.dataset.namespace === freshUrl,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- continue traversing an iconfont script URL list when the current URL is already cached or otherwise invalid
- keep React and Vue loaders behaviorally aligned
- add isolated regression coverage for both packages

## Root cause

`customCache` is shared across every `createFromIconfontCN` factory in a package. Array URLs are loaded sequentially in reverse order so earlier entries keep symbol precedence, but recursion was scheduled only inside the valid-current-URL branch.

If a later factory shared one already-loaded URL and also introduced a new URL, the cached entry could become the first URL inspected after reversal. The loader then returned without ever visiting the remaining new URL.

The fix skips an invalid or cached entry and continues to the next list item. Existing sequential `load` and `error` behavior for newly appended scripts is unchanged.

## Base reproduction

Against exact base `6c18c63fbcfcf71dae09cd6bd6d63a48f8b688f1`, dedicated React and Vue tests each:

1. primed the shared cache with one script URL;
2. created another factory with a fresh URL plus the cached URL;
3. observed that no script was created for the fresh URL.

Both tests failed on base with `expected false to be true` and pass after the fix.

## Verification

- React focused regression: 1/1 passed
- Vue focused regression: 1/1 passed
- React full suite: 47/47 passed
- Vue full suite: 14/14 passed
- React and Vue source lint: passed
- React compile: UMD, ESM, CJS, and declarations passed
- Vue compile: ESM, CJS, and declarations passed
- Prettier check for all changed files: passed
- `git diff --check`: passed

The head was created from current master, and no open PR touches any of the four changed paths.

AI assistance disclosure: Codex was used to trace the shared-cache sequence, construct the exact-base regressions, audit open PR overlap, and run validation. The failure and final diff were verified before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化 IconFont 脚本加载逻辑：遇到空 URL 或已缓存 URL 时，会继续尝试加载列表中的后续 URL。
  - 提升 React 和 Vue 版本中多个脚本地址的加载可靠性，避免因单个无效地址导致后续资源无法加载。

- **测试**
  - 新增 React 和 Vue 相关测试，验证已缓存脚本地址不会阻止新的脚本继续加载。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->