### PR TITLE
fix(deps): force a single @types/react copy via root overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "lint": "ut lint --workspaces"
   },
   "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@types/react-test-renderer": "^19.1.0",
     "@eslint/js": "^9.17.0",
     "typescript-eslint": "^8.18.2",
     "eslint-plugin-jest": "^28.10.0",
@@ -28,6 +31,9 @@
   "license": "MIT",
   "repository": "git@github.com:ant-design/ant-design-icons.git",
   "overrides": {
-    "cheerio": "1.0.0-rc.12"
+    "cheerio": "1.0.0-rc.12",
+    "@types/react": "$@types/react",
+    "@types/react-dom": "$@types/react-dom",
+    "@types/react-test-renderer": "$@types/react-test-renderer"
   }
 }


### PR DESCRIPTION
## Why another PR after #766

#766 bumped the stale `@types/react@^16` ranges in `packages/icons-react-native`, and CI went green on that commit ([run 33153846331](https://github.com/ant-design/ant-design-icons/actions/runs/33153846331)). That was necessary but **not sufficient**: it fixed the *declared* range, not the *installed tree*.

This repo has no lockfile (`package-lock.json`, `pnpm-lock.yaml`, `bun.lock`, `yarn.lock` are all git-ignored, and Dependabot says so explicitly in its own failing job: *"Depabot can't update vulnerable dependencies for projects without a lockfile or pinned version requirement"*). CI installs with `ut install --ignore-scripts` on a fresh runner, so which copy of `@types/react` ends up nested under `packages/icons-react-native/node_modules` is decided by the resolver at install time, not by us.

## Root cause, reproduced locally

Minimal npm-workspaces repro (root + `icons-react` on `@types/react@^19` + `icons-react-native` with `@types/react-native@^0.72`):

| install tree | `tsc` on the generated `fill.tsx` |
|---|---|
| single hoisted `@types/react@19.2.18` | exit 0 ✅ |
| hoisted `19.2.18` **+** nested `16.14.70` under `icons-react-native` | `TS2786: 'Text' cannot be used as a JSX component` ❌ (identical to [job 98781833030](https://github.com/ant-design/ant-design-icons/actions/runs/33150726597/job/98781833030)) |

`@types/react-native@0.72` declares `@types/react: "*"`, so it dedupes to whatever copy the resolver picks. If a v16 copy lands in the nested slot, RN's `Text` extends v19 `Component` (no `refs` since v18) while the JSX check resolves `ReactInstance` from v16 (requires `refs`) → declaration generation dies. Bumping the range only helps if no v16 copy ever lands; it does not *prevent* one from landing.

## Fix

Make the version single-source-of-truth at the workspace root and force every transitive copy onto it:

- root `devDependencies`: `@types/react@^19.2.14`, `@types/react-dom@^19.2.3`, `@types/react-test-renderer@^19.1.0`
- root `overrides`: `"@types/react": "$@types/react"` (same for `-dom` / `-test-renderer`), following the existing `cheerio` override pattern

## Verification (local)

1. Repro with a **deliberately stale** nested `@types/react@16.14.70` extracted into `packages/icons-react-native/node_modules`, no overrides → `TS2786` reproduces.
2. Same dirtied tree, add the overrides → `npm install` removes the stale nested copy, `tsc` exit 0.
3. Pre-#766 declaration (`@types/react@^16.4.12` in the RN package) **with** overrides → only one copy resolves (`19.2.18`), `tsc` exit 0. The override wins over the package-level range, which is the point: it holds even if someone reintroduces a stale range.

## What this does not fix

🔴 The real defect is "no lockfile". This PR is a mitigation, not a cure — an install that resolves `@types/react` to two different majors for *other* reasons (or a future `@types/react-native` that needs v18) can still split the tree. The durable fix is committing a lockfile and installing from it, which also unblocks the failing Dependabot security job. That is a bigger change (CI + `ut` behaviour + every maintainer's local flow) and deliberately out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **维护**
  * 新增 React、React DOM 和 React Test Renderer 的类型依赖。
  * 锁定相关类型包版本，提升依赖版本一致性与稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
